### PR TITLE
Hot-reloading improvements

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,7 +4,7 @@ root = "."
 tmp_dir = "tmp"
 
 [build]
-exclude_dir = ["cypress", "docker", "tmp", "web/assets", "web/static", "node_modules"]
+exclude_dir = ["cypress", "docker", "tmp", "web/assets", "web/static", "node_modules", "json-server"]
 cmd = "go build -gcflags='all=-N -l' -o ./tmp/main ."
 bin = "tmp/main"
 full_bin = "dlv exec --accept-multiclient --log --headless --continue --listen :2345 --api-version 2 ./tmp/main"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 cypress/screenshots
 cypress/videos
+tmp
+main
+web/static

--- a/docker/sirius-deputy-hub/Dockerfile
+++ b/docker/sirius-deputy-hub/Dockerfile
@@ -11,21 +11,9 @@ RUN apk update \
     git \
     && update-ca-certificates
 
-### Development with hot reload and debugger
-FROM base AS dev
-WORKDIR /app
-
-RUN go get -u github.com/cosmtrek/air && go install github.com/go-delve/delve/cmd/dlv@latest
-EXPOSE 8080
-EXPOSE 2345
-
-ENTRYPOINT ["air"]
-
 FROM node:14.17.5-alpine3.14 as asset-env
 
 WORKDIR /app
-
-RUN mkdir -p web/static
 
 COPY web/assets web/assets
 COPY webpack.config.js .
@@ -34,6 +22,19 @@ COPY yarn.lock .
 
 RUN yarn install
 RUN yarn build
+
+### Development with hot reload and debugger
+FROM base AS dev
+
+WORKDIR /app
+
+COPY --from=asset-env /app/web/static web/static
+
+RUN go get -u github.com/cosmtrek/air && go install github.com/go-delve/delve/cmd/dlv@latest
+EXPOSE 8080
+EXPOSE 2345
+
+ENTRYPOINT ["air"]
 
 FROM base as build-env
 


### PR DESCRIPTION
Docker compose stack for local development was inadvertently using local built assets instead of the containers. Also reduces the scope of watched files for hot-reloading