### PR TITLE
sw-5218 fix success banner location #minor

### DIFF
--- a/web/template/deputy-details.gotmpl
+++ b/web/template/deputy-details.gotmpl
@@ -1,9 +1,9 @@
 {{ template "page" . }}
 {{ define "main" }}
-    {{ template "deputy-hub" . }}
     {{ if .Success }}
         {{ template "success-banner" . }}
     {{ end }}
+    {{ template "deputy-hub" . }}
     {{ template "navigation" . }}
 
 

--- a/web/template/manage-team-details.gotmpl
+++ b/web/template/manage-team-details.gotmpl
@@ -1,9 +1,9 @@
 {{ template "page" . }}
 {{ define "main" }}
-    {{ template "deputy-hub" . }}
     {{ if .Success }}
         {{ template "success-banner" " You have successfully edited your details." }}
     {{ end }}
+    {{ template "deputy-hub" . }}
     {{ template "error-summary" .Errors }}
     <main role="main" class="govuk-main-wrapper">
         <div class="govuk-grid-row govuk-!-margin-top-5">


### PR DESCRIPTION
Noticed success banners were in different places across apps, this PR is to correct those in deputy hub