### PR TITLE
Pin colors to 1.4.0 #patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
         "test-server": "cd internal/server && go test",
         "cypress": "cypress open",
         "fmt": "prettier --write ."
+    },
+    "resolutions": {
+        "colors": "1.4.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,7 +1513,7 @@ colorette@^1.2.1, colorette@^1.2.2, colorette@^1.3.0:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.3.0.tgz#ff45d2f0edb244069d3b772adeb04fed38d0a0af"
   integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
 
-colors@^1.1.2:
+colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
To ensure we avoid a security issue in >1.4.4.

Can be removed when the package is back under secure control, or our core dependencies stop using it.