### PR TITLE
SW-5421 amend health check route ordering to fix check failures

### DIFF
--- a/cypress/integration/health_check.spec.js
+++ b/cypress/integration/health_check.spec.js
@@ -1,0 +1,9 @@
+describe("Health check", () => {
+    it("returns 200 status", () => {
+        cy.request({
+            url: '/supervision/deputies/health-check',
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+        })
+    });
+});

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,6 +36,8 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 	wrap := errorHandler(logger, client, templates["error.gotmpl"], prefix, siriusPublicURL)
 
 	router := mux.NewRouter()
+	router.Handle("/health-check", healthCheck())
+
 	router.Handle("/{id}",
 		wrap(
 			renderTemplateForDeputyHub(client, defaultPATeam, templates["deputy-details.gotmpl"])))
@@ -75,8 +77,6 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 	router.Handle("/{id}/manage-deputy-contact-details",
 		wrap(
 			renderTemplateForManageDeputyContactDetails(client, defaultPATeam, templates["manage-deputy-contact-details.gotmpl"])))
-
-	router.Handle("/health-check", healthCheck())
 
 	static := staticFileHandler(webDir)
 	router.PathPrefix("/assets/").Handler(static)


### PR DESCRIPTION
#patch the deputy hub container failed it's health check which is likely due to the order of the routes which should be in alphabetical order but this was affected with the pa routing changed and the `/deputy` prefix was removed. This should fix the ordering and places /`health-check` route at the top of the order. 