### PR TITLE
Refactor success messages

### DIFF
--- a/internal/server/add_firm.go
+++ b/internal/server/add_firm.go
@@ -20,7 +20,6 @@ type addFirmVars struct {
 	DeputyDetails sirius.DeputyDetails
 	Error         string
 	Errors        sirius.ValidationErrors
-	Success       bool
 	DeputyId      int
 }
 

--- a/internal/server/assurance_visits.go
+++ b/internal/server/assurance_visits.go
@@ -19,7 +19,6 @@ type AssuranceVisitsVars struct {
 	Error           string
 	Errors          sirius.ValidationErrors
 	ErrorMessage    string
-	Success         bool
 	SuccessMessage  string
 	AssuranceVisits []sirius.AssuranceVisits
 }
@@ -29,13 +28,21 @@ func renderTemplateForAssuranceVisits(client AssuranceVisit, tmpl Template) Hand
 		ctx := getContext(r)
 		routeVars := mux.Vars(r)
 		deputyId, _ := strconv.Atoi(routeVars["id"])
-		hasSuccess, successMessage := createSuccessAndSuccessMessageForVars(r.URL.String(), "", "")
+
+		var successMessage string
+		switch r.URL.Query().Get("success") {
+		case "addAssuranceVisit":
+			successMessage = "Assurance process updated"
+		case "manageAssuranceVisit":
+			successMessage = "Assurance visit updated"
+		default:
+			successMessage = ""
+		}
 
 		vars := AssuranceVisitsVars{
 			Path:           r.URL.Path,
 			XSRFToken:      ctx.XSRFToken,
 			DeputyDetails:  deputyDetails,
-			Success:        hasSuccess,
 			SuccessMessage: successMessage,
 		}
 

--- a/internal/server/change_ecm.go
+++ b/internal/server/change_ecm.go
@@ -21,7 +21,6 @@ type changeECMHubVars struct {
 	EcmTeamDetails []sirius.TeamMember
 	Error          string
 	Errors         sirius.ValidationErrors
-	Success        bool
 	SuccessMessage string
 	ErrorMessage   string
 	DefaultPaTeam  int
@@ -41,10 +40,9 @@ func renderTemplateForChangeECM(client ChangeECMInformation, defaultPATeam int, 
 
 		switch r.Method {
 		case http.MethodGet:
-			var SuccessMessage string
-			hasSuccess := hasSuccessInUrl(r.URL.String(), "/"+strconv.Itoa(deputyId))
-			if hasSuccess {
-				SuccessMessage = "new ecm is" + deputyDetails.ExecutiveCaseManager.EcmName
+			var successMessage string
+			if r.URL.Query().Get("success") == "true" {
+				successMessage = "new ecm is" + deputyDetails.ExecutiveCaseManager.EcmName
 			}
 
 			vars := changeECMHubVars{
@@ -53,8 +51,7 @@ func renderTemplateForChangeECM(client ChangeECMInformation, defaultPATeam int, 
 				DeputyDetails:  deputyDetails,
 				DefaultPaTeam:  defaultPATeam,
 				EcmTeamDetails: ecmTeamDetails,
-				Success:        hasSuccess,
-				SuccessMessage: SuccessMessage,
+				SuccessMessage: successMessage,
 			}
 
 			vars.ErrorMessage = checkForDefaultEcmId(deputyDetails.ExecutiveCaseManager.EcmId, defaultPATeam)

--- a/internal/server/deputy_hub_test.go
+++ b/internal/server/deputy_hub_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/ministryofjustice/opg-sirius-supervision-deputy-hub/internal/sirius"
@@ -52,32 +53,32 @@ func TestNavigateToDeputyHub(t *testing.T) {
 }
 
 func TestCreateSuccessAndSuccessMessageForVarsReturnsMessageOnEcmSuccess(t *testing.T) {
-	Success, SuccessMessage := createSuccessAndSuccessMessageForVars("/76/?success=ecm", "Jon Snow", "defaultPATeam")
-	assert.Equal(t, true, Success)
+	u, _ := url.Parse("http::deputyhub/76/?success=ecm")
+	SuccessMessage := getSuccessFromUrl(u, "Jon Snow", "defaultPATeam")
 	assert.Equal(t, SuccessMessage, "Ecm changed to Jon Snow")
 }
 
 func TestCreateSuccessAndSuccessMessageForVarsReturnsMessageOnTeamDetailsSuccess(t *testing.T) {
-	Success, SuccessMessage := createSuccessAndSuccessMessageForVars("/76/?success=teamDetails", "Jon Snow", "defaultPATeam")
-	assert.Equal(t, true, Success)
+	u, _ := url.Parse("http::deputyhub/76/?success=teamDetails")
+	SuccessMessage := getSuccessFromUrl(u, "Jon Snow", "defaultPATeam")
 	assert.Equal(t, SuccessMessage, "Team details updated")
 }
 
 func TestCreateSuccessAndSuccessMessageForVarsReturnsMessageOnDeputyContactDetailsSuccess(t *testing.T) {
-	Success, SuccessMessage := createSuccessAndSuccessMessageForVars("/76/?success=deputyDetails", "Jon Snow", "defaultPATeam")
-	assert.Equal(t, true, Success)
+	u, _ := url.Parse("http::deputyhub/76/?success=deputyDetails")
+	SuccessMessage := getSuccessFromUrl(u, "Jon Snow", "defaultPATeam")
 	assert.Equal(t, SuccessMessage, "Deputy details updated")
 }
 
 func TestCreateSuccessAndSuccessMessageForVarsReturnsNilForAnyOtherText(t *testing.T) {
-	Success, SuccessMessage := createSuccessAndSuccessMessageForVars("/76/?success=otherMessage", "Jon Snow", "defaultPATeam")
-	assert.Equal(t, false, Success)
+	u, _ := url.Parse("http::deputyhub/76/?success=otherMessage")
+	SuccessMessage := getSuccessFromUrl(u, "Jon Snow", "defaultPATeam")
 	assert.Equal(t, SuccessMessage, "")
 }
 
 func TestCreateSuccessAndSuccessMessageForVarsReturnsNilIfNoSuccess(t *testing.T) {
-	Success, SuccessMessage := createSuccessAndSuccessMessageForVars("/76/", "Jon Snow", "defaultPATeam")
-	assert.Equal(t, false, Success)
+	u, _ := url.Parse("http::deputyhub/76/")
+	SuccessMessage := getSuccessFromUrl(u, "Jon Snow", "defaultPATeam")
 	assert.Equal(t, SuccessMessage, "")
 }
 
@@ -90,19 +91,19 @@ func TestCheckForDefaultEcmIdReturnsNullIfFalse(t *testing.T) {
 }
 
 func TestCreateSuccessAndSuccessMessageForVarsReturnsMessageOnDeputyDetailsSuccess(t *testing.T) {
-	Success, SuccessMessage := createSuccessAndSuccessMessageForVars("/76/?success=deputyDetails", "Jon Snow", "defaultPATeam")
-	assert.Equal(t, true, Success)
+	u, _ := url.Parse("http::deputyhub/76/?success=deputyDetails")
+	SuccessMessage := getSuccessFromUrl(u, "Jon Snow", "defaultPATeam")
 	assert.Equal(t, SuccessMessage, "Deputy details updated")
 }
 
 func TestCreateSuccessAndSuccessMessageForVarsReturnsMessageUseExistingFirmSuccess(t *testing.T) {
-	Success, SuccessMessage := createSuccessAndSuccessMessageForVars("/deputy/76/?success=firm", "Jon Snow", "defaultPATeam")
-	assert.Equal(t, true, Success)
+	u, _ := url.Parse("http::deputyhub/76/?success=firm")
+	SuccessMessage := getSuccessFromUrl(u, "Jon Snow", "defaultPATeam")
 	assert.Equal(t, SuccessMessage, "Firm changed to defaultPATeam")
 }
 
 func TestCreateSuccessAndSuccessMessageForVarsReturnsMessageAddFirmSuccess(t *testing.T) {
-	Success, SuccessMessage := createSuccessAndSuccessMessageForVars("/deputy/76/?success=newFirm", "Jon Snow", "defaultPATeam")
-	assert.Equal(t, true, Success)
+	u, _ := url.Parse("http::deputyhub/deputy/76/?success=newFirm")
+	SuccessMessage := getSuccessFromUrl(u, "Jon Snow", "defaultPATeam")
 	assert.Equal(t, SuccessMessage, "Firm added")
 }

--- a/internal/server/deputy_notes.go
+++ b/internal/server/deputy_notes.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ministryofjustice/opg-sirius-supervision-deputy-hub/internal/sirius"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 type DeputyHubNotesInformation interface {
@@ -23,7 +22,6 @@ type deputyHubNotesVars struct {
 	Error          string
 	Errors         sirius.ValidationErrors
 	ErrorMessage   string
-	Success        bool
 	SuccessMessage string
 }
 
@@ -32,16 +30,10 @@ type addNoteVars struct {
 	XSRFToken     string
 	Title         string
 	Note          string
-	Success       bool
 	Error         sirius.ValidationError
 	Errors        sirius.ValidationErrors
 	ErrorMessage  string
 	DeputyDetails sirius.DeputyDetails
-}
-
-func hasSuccessInUrl(url string, prefix string) bool {
-	urlTrim := strings.TrimPrefix(url, prefix)
-	return urlTrim == "?success=true"
 }
 
 func renderTemplateForDeputyHubNotes(client DeputyHubNotesInformation, defaultPATeam int, tmpl Template) Handler {
@@ -59,15 +51,17 @@ func renderTemplateForDeputyHubNotes(client DeputyHubNotesInformation, defaultPA
 				return err
 			}
 
-			hasSuccess := hasSuccessInUrl(r.URL.String(), "/"+strconv.Itoa(deputyId)+"/notes")
+			successMessage := ""
+			if r.URL.Query().Get("success") == "true" {
+				successMessage = "Note added"
+			}
 
 			vars := deputyHubNotesVars{
 				Path:           r.URL.Path,
 				XSRFToken:      ctx.XSRFToken,
 				DeputyDetails:  deputyDetails,
 				DeputyNotes:    deputyNotes,
-				Success:        hasSuccess,
-				SuccessMessage: "Note added",
+				SuccessMessage: successMessage,
 			}
 
 			vars.ErrorMessage = checkForDefaultEcmId(deputyDetails.ExecutiveCaseManager.EcmId, defaultPATeam)

--- a/internal/server/deputy_notes_test.go
+++ b/internal/server/deputy_notes_test.go
@@ -50,7 +50,7 @@ func TestGetNotes(t *testing.T) {
 	defaultPATeam := 23
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest("GET", "/path", nil)
+	r, _ := http.NewRequest("GET", "/path?success=true", nil)
 
 	handler := renderTemplateForDeputyHubNotes(client, defaultPATeam, template)
 	err := handler(sirius.PermissionSet{}, sirius.DeputyDetails{}, w, r)

--- a/internal/server/edit_deputy_hub.go
+++ b/internal/server/edit_deputy_hub.go
@@ -20,7 +20,6 @@ type editDeputyHubVars struct {
 	Error         string
 	Errors        sirius.ValidationErrors
 	ErrorMessage  string
-	Success       bool
 }
 
 func renderTemplateForEditDeputyHub(client EditDeputyHubInformation, defaultPATeam int, tmpl Template) Handler {

--- a/json-server/success-rerouter.js
+++ b/json-server/success-rerouter.js
@@ -1,6 +1,6 @@
 const getSuccessRoute = (req) => {
-    return req.headers?.cookie?.match(/success-route=(?<failRoute>\w+);/)
-        ?.groups.failRoute;
+    return req.headers?.cookie?.match(/success-route=(?<successRoute>\w+);/)
+        ?.groups.successRoute;
 };
 
 module.exports = (req, res, next) => {

--- a/web/template/assurance-visit.gotmpl
+++ b/web/template/assurance-visit.gotmpl
@@ -1,6 +1,6 @@
 {{ template "page" . }}
 {{ define "main" }}
-    {{ if .Success }}
+    {{ if .SuccessMessage }}
         {{ template "success-banner" . }}
     {{ end }}
     {{ template "error-summary" (rename_errors .Errors) }}

--- a/web/template/manage-team-details.gotmpl
+++ b/web/template/manage-team-details.gotmpl
@@ -1,8 +1,5 @@
 {{ template "page" . }}
 {{ define "main" }}
-    {{ if .Success }}
-        {{ template "success-banner" " You have successfully edited your details." }}
-    {{ end }}
     {{ template "error-summary" .Errors }}
     {{ if eq .DeputyDetails.DeputyType.Handle "PA" }}
         {{ if ne .ErrorMessage "" }}

--- a/web/template/notes.gotmpl
+++ b/web/template/notes.gotmpl
@@ -1,6 +1,6 @@
 {{ template "page" . }}
 {{ define "main" }}
-    {{ if .Success }}
+    {{ if .SuccessMessage }}
         {{ template "success-banner" . }}
     {{ end }}
     {{ template "error-summary" .Errors }}

--- a/web/template/pa-hub/pa-deputy-details.gotmpl
+++ b/web/template/pa-hub/pa-deputy-details.gotmpl
@@ -1,5 +1,5 @@
 {{ define "pa-deputy-details" }}
-    {{ if .Success }}
+    {{ if .SuccessMessage }}
         {{ template "success-banner" . }}
     {{ end }}
     {{ if ne .ErrorMessage "" }}

--- a/web/template/pro-hub/pro-deputy-details.gotmpl
+++ b/web/template/pro-hub/pro-deputy-details.gotmpl
@@ -1,5 +1,5 @@
 {{ define "pro-deputy-details" }}
-    {{ if .Success }}
+    {{ if .SuccessMessage }}
         {{ template "success-banner" . }}
     {{ end }}
     {{ template "pro-deputy-header" . }}


### PR DESCRIPTION
Success messages all required an unnecessary boolean (an empty string is already a falsy value in Go templates) and parsed the string rather than using the in-built Query function available in the url package.