### PR TITLE
Sw 4983 task timeline

### DIFF
--- a/cypress/e2e/notes.cy.js
+++ b/cypress/e2e/notes.cy.js
@@ -20,6 +20,18 @@ describe("Notes", () => {
        });
     });
 
+    describe("Viewing notes", () => {
+        it("should display notes correctly", () => {
+            cy.visit("/supervision/deputies/2/notes");
+            cy.get(
+                ":nth-last-child(1) > .moj-timeline__header > .moj-timeline__title"
+            ).should("contain", "New note title");
+            cy.get(
+                ":nth-last-child(1) > .moj-timeline__description"
+            ).should("contain", "Note text entered");
+        });
+    })
+
     describe("Adding a note", () => {
         beforeEach(() => {
             cy.visit("/supervision/deputies/2/notes/add-note");
@@ -59,19 +71,6 @@ describe("Notes", () => {
                 cy.get(
                     "body > div > main > div.moj-banner.moj-banner--success > div"
                 ).should("contain", "Note added");
-            });
-
-            it("shows new note on the timeline", () => {
-                cy.get("#title").type("New note title");
-                cy.get("#note").type("Note text entered");
-                cy.get("#add-note-form").submit();
-                cy.url().should("contain", "/supervision/deputies/2/notes");
-                cy.get(
-                    ":nth-last-child(1) > .moj-timeline__header > .moj-timeline__title"
-                ).should("contain", "New note title");
-                cy.get(
-                    ":nth-last-child(1) > .moj-timeline__description"
-                ).should("contain", "Note text entered");
             });
         });
 

--- a/cypress/e2e/notes.cy.js
+++ b/cypress/e2e/notes.cy.js
@@ -22,7 +22,7 @@ describe("Notes", () => {
 
     describe("Adding a note", () => {
         beforeEach(() => {
-            cy.visit("/supervision/deputies/1/notes/add-note");
+            cy.visit("/supervision/deputies/2/notes/add-note");
         });
 
         describe("Successfully adding a note", () => {
@@ -55,7 +55,7 @@ describe("Notes", () => {
                 cy.get("#title").type("title");
                 cy.get("#note").type("note");
                 cy.get("#add-note-form").submit();
-                cy.url().should("contain", "/supervision/deputies/1/notes");
+                cy.url().should("contain", "/supervision/deputies/2/notes");
                 cy.get(
                     "body > div > main > div.moj-banner.moj-banner--success > div"
                 ).should("contain", "Note added");
@@ -65,7 +65,7 @@ describe("Notes", () => {
                 cy.get("#title").type("New note title");
                 cy.get("#note").type("Note text entered");
                 cy.get("#add-note-form").submit();
-                cy.url().should("contain", "/supervision/deputies/1/notes");
+                cy.url().should("contain", "/supervision/deputies/2/notes");
                 cy.get(
                     ":nth-last-child(1) > .moj-timeline__header > .moj-timeline__title"
                 ).should("contain", "New note title");
@@ -80,7 +80,7 @@ describe("Notes", () => {
                 .should("contain", "Cancel")
                 .click();
             cy.get(".govuk-heading-l").should("contain", "Notes");
-            cy.url().should("contain", "/supervision/deputies/1/notes");
+            cy.url().should("contain", "/supervision/deputies/2/notes");
         });
 
         it("shows error message when submitting invalid data", () => {

--- a/cypress/e2e/tasks.cy.js
+++ b/cypress/e2e/tasks.cy.js
@@ -67,7 +67,7 @@ describe("Tasks", () => {
             cy.visit("/supervision/deputies/1/timeline");
 
             cy.get('[data-cy="task-created-event"]').within(() => {
-                cy.contains(".moj-timeline__title", "Assurance visit follow up task created by");
+                cy.contains(".moj-timeline__title", "Assurance visit follow up task created");
                 cy.contains(".moj-timeline__byline", "by Lay Team 1 - (Supervision) (0123456789)");
 
                 cy.get(".moj-timeline__description").get("li")
@@ -82,7 +82,7 @@ describe("Tasks", () => {
 
     describe("Task note", () => {
         it("displays the task note title in the Notes tab correctly", () => {
-            cy.visit("/supervision/deputies/1/notes");
+            cy.visit("/supervision/deputies/3/notes");
             cy.contains(".moj-timeline__title", "General enquiry task created");
         });
     })

--- a/cypress/e2e/tasks.cy.js
+++ b/cypress/e2e/tasks.cy.js
@@ -61,4 +61,22 @@ describe("Tasks", () => {
             });
         });
     });
+
+    describe("Task timeline", () => {
+        it("displays a task timeline event", () => {
+            cy.visit("/supervision/deputies/1/timeline");
+
+            cy.get('[data-cy="task-created-event"]').within(() => {
+                cy.contains(".moj-timeline__title", "Assurance visit follow up task created by");
+                cy.contains(".moj-timeline__byline", "by Lay Team 1 - (Supervision) (0123456789)");
+
+                cy.get(".moj-timeline__description").get("li")
+                    .should("contain", "Assigned to PA Team Workflow")
+                    .next()
+                    .should("contain", "Due date 13/07/2023")
+                    .next()
+                    .should("contain", "This is a note");
+            });
+        });
+    })
 });

--- a/cypress/e2e/tasks.cy.js
+++ b/cypress/e2e/tasks.cy.js
@@ -79,4 +79,11 @@ describe("Tasks", () => {
             });
         });
     })
+
+    describe("Task note", () => {
+        it("displays the task note title in the Notes tab correctly", () => {
+            cy.visit("/supervision/deputies/1/notes");
+            cy.contains(".moj-timeline__title", "General enquiry task created");
+        });
+    })
 });

--- a/cypress/e2e/timeline.cy.js
+++ b/cypress/e2e/timeline.cy.js
@@ -15,30 +15,20 @@ describe("Timeline", () => {
     it("contains appropriate test data for a timeline event", () => {
         cy.visit("/supervision/deputies/1/timeline");
 
-        cy.get(".moj-timeline__title").should(
-            "contain",
-            "New client added to deputyship"
-        );
-        cy.get(".moj-timeline__byline").should(
-            "contain",
-            "by system admin (12345678)"
-        );
-        cy.get("time").should("contain", "09/09/2021");
-        cy.get(".govuk-list > :nth-child(1)").should(
-            "contain",
-            "Order number: 03305972"
-        );
-        cy.get(".govuk-list > :nth-child(2)").should(
-            "contain",
-            "Sirius ID: 7000-0000-1995"
-        );
-        cy.get(".govuk-list > :nth-child(3)").should(
-            "contain",
-            "Order type: pfa"
-        );
-        cy.get(".govuk-list > :nth-child(4)").should(
-            "contain",
-            "Client: Duke John Fearless"
-        );
+        cy.get('[data-cy="new-client-added-event"]').within(() => {
+            cy.contains(".moj-timeline__title", "New client added to deputyship");
+            cy.contains(".moj-timeline__byline", "by system admin (12345678)");
+
+            cy.get("time").should("contain", "09/09/2021");
+
+            cy.get(".moj-timeline__description").get("li")
+                .should("contain", "Order number: 03305972")
+                .next()
+                .should("contain", "Sirius ID: 7000-0000-1995")
+                .next()
+                .should("contain", "Order type: pfa")
+                .next()
+                .should("contain", "Client: Duke John Fearless");
+        });
     });
 });

--- a/internal/server/add_task.go
+++ b/internal/server/add_task.go
@@ -9,7 +9,7 @@ import (
 
 type AddTasksClient interface {
 	AddTask(ctx sirius.Context, deputyId int, taskType string, dueDate string, notes string, assigneeId int) error
-	GetTaskTypes(ctx sirius.Context, deputy sirius.DeputyDetails) ([]sirius.TaskType, error)
+	GetTaskTypesForDeputyType(ctx sirius.Context, deputy sirius.DeputyDetails) ([]sirius.TaskType, error)
 	GetDeputyTeamMembers(ctx sirius.Context, defaultPATeam int, deputy sirius.DeputyDetails) ([]sirius.TeamMember, error)
 }
 
@@ -35,7 +35,7 @@ func renderTemplateForAddTask(client AddTasksClient, tmpl Template) Handler {
 		ctx := getContext(r)
 		deputyId := deputyDetails.ID
 
-		taskTypes, err := client.GetTaskTypes(ctx, deputyDetails)
+		taskTypes, err := client.GetTaskTypesForDeputyType(ctx, deputyDetails)
 		if err != nil {
 			return err
 		}

--- a/internal/server/add_task.go
+++ b/internal/server/add_task.go
@@ -8,8 +8,8 @@ import (
 )
 
 type AddTasksClient interface {
-	AddTask(ctx sirius.Context, deputyId int, taskType string, dueDate string, notes string, assigneeId int) error
-	GetTaskTypesForDeputyType(ctx sirius.Context, deputy sirius.DeputyDetails) ([]sirius.TaskType, error)
+	AddTask(ctx sirius.Context, deputyId int, taskType string, typeName string, dueDate string, notes string, assigneeId int) error
+	GetTaskTypesForDeputyType(ctx sirius.Context, deputyType string) ([]sirius.TaskType, error)
 	GetDeputyTeamMembers(ctx sirius.Context, defaultPATeam int, deputy sirius.DeputyDetails) ([]sirius.TeamMember, error)
 }
 
@@ -31,11 +31,9 @@ func renderTemplateForAddTask(client AddTasksClient, tmpl Template) Handler {
 		if r.Method != http.MethodGet && r.Method != http.MethodPost {
 			return StatusError(http.StatusMethodNotAllowed)
 		}
-
 		ctx := getContext(r)
-		deputyId := deputyDetails.ID
 
-		taskTypes, err := client.GetTaskTypesForDeputyType(ctx, deputyDetails)
+		taskTypes, err := client.GetTaskTypesForDeputyType(ctx, deputyDetails.DeputyType.Handle)
 		if err != nil {
 			return err
 		}
@@ -59,6 +57,7 @@ func renderTemplateForAddTask(client AddTasksClient, tmpl Template) Handler {
 		} else {
 			var (
 				taskType   = r.PostFormValue("tasktype")
+				typeName   = getTaskName(taskType, taskTypes)
 				dueDate    = r.PostFormValue("duedate")
 				notes      = r.PostFormValue("notes")
 				ecm        = r.PostFormValue("assignedto")
@@ -72,7 +71,7 @@ func renderTemplateForAddTask(client AddTasksClient, tmpl Template) Handler {
 				assigneeId, _ = strconv.Atoi(ecm)
 			}
 
-			err := client.AddTask(ctx, deputyId, taskType, dueDate, notes, assigneeId)
+			err := client.AddTask(ctx, deputyDetails.ID, taskType, typeName, dueDate, notes, assigneeId)
 
 			if verr, ok := err.(sirius.ValidationError); ok {
 				vars = AddTaskVars{
@@ -100,7 +99,16 @@ func renderTemplateForAddTask(client AddTasksClient, tmpl Template) Handler {
 				}
 			}
 
-			return Redirect(fmt.Sprintf("/%d/tasks?success="+taskName, deputyId))
+			return Redirect(fmt.Sprintf("/%d/tasks?success="+taskName, deputyDetails.ID))
 		}
 	}
+}
+
+func getTaskName(handle string, types []sirius.TaskType) string {
+	for _, t := range types {
+		if handle == t.Handle {
+			return t.Description
+		}
+	}
+	return ""
 }

--- a/internal/server/add_tasks_test.go
+++ b/internal/server/add_tasks_test.go
@@ -24,7 +24,7 @@ type mockAddTasksClient struct {
 	selectedAssignee int
 }
 
-func (m *mockAddTasksClient) AddTask(ctx sirius.Context, deputyId int, taskType string, dueDate string, notes string, assigneeId int) error {
+func (m *mockAddTasksClient) AddTask(ctx sirius.Context, deputyId int, taskType string, typeName string, dueDate string, notes string, assigneeId int) error {
 	m.count += 1
 	m.lastCtx = ctx
 	m.selectedAssignee = assigneeId
@@ -32,7 +32,7 @@ func (m *mockAddTasksClient) AddTask(ctx sirius.Context, deputyId int, taskType 
 	return m.verr
 }
 
-func (m *mockAddTasksClient) GetTaskTypesForDeputyType(ctx sirius.Context, details sirius.DeputyDetails) ([]sirius.TaskType, error) {
+func (m *mockAddTasksClient) GetTaskTypesForDeputyType(ctx sirius.Context, deputyType string) ([]sirius.TaskType, error) {
 	m.count += 1
 	m.lastCtx = ctx
 

--- a/internal/server/add_tasks_test.go
+++ b/internal/server/add_tasks_test.go
@@ -32,7 +32,7 @@ func (m *mockAddTasksClient) AddTask(ctx sirius.Context, deputyId int, taskType 
 	return m.verr
 }
 
-func (m *mockAddTasksClient) GetTaskTypes(ctx sirius.Context, details sirius.DeputyDetails) ([]sirius.TaskType, error) {
+func (m *mockAddTasksClient) GetTaskTypesForDeputyType(ctx sirius.Context, details sirius.DeputyDetails) ([]sirius.TaskType, error) {
 	m.count += 1
 	m.lastCtx = ctx
 

--- a/internal/server/deputy_events.go
+++ b/internal/server/deputy_events.go
@@ -1,22 +1,19 @@
 package server
 
 import (
-	"net/http"
-	"strconv"
-
-	"github.com/gorilla/mux"
 	"github.com/ministryofjustice/opg-sirius-supervision-deputy-hub/internal/sirius"
+	"net/http"
 )
 
 type DeputyHubEventInformation interface {
-	GetDeputyEvents(sirius.Context, int) (sirius.DeputyEventCollection, error)
+	GetDeputyEvents(sirius.Context, sirius.DeputyDetails) (sirius.DeputyEvents, error)
 }
 
 type deputyHubEventVars struct {
 	Path          string
 	XSRFToken     string
 	DeputyDetails sirius.DeputyDetails
-	DeputyEvents  sirius.DeputyEventCollection
+	DeputyEvents  sirius.DeputyEvents
 	Error         string
 }
 
@@ -27,9 +24,7 @@ func renderTemplateForDeputyHubEvents(client DeputyHubEventInformation, tmpl Tem
 		}
 
 		ctx := getContext(r)
-		routeVars := mux.Vars(r)
-		deputyId, _ := strconv.Atoi(routeVars["id"])
-		deputyEvents, err := client.GetDeputyEvents(ctx, deputyId)
+		deputyEvents, err := client.GetDeputyEvents(ctx, deputyDetails)
 		if err != nil {
 			return err
 		}

--- a/internal/server/deputy_events.go
+++ b/internal/server/deputy_events.go
@@ -6,7 +6,7 @@ import (
 )
 
 type DeputyHubEventInformation interface {
-	GetDeputyEvents(sirius.Context, sirius.DeputyDetails) (sirius.DeputyEvents, error)
+	GetDeputyEvents(sirius.Context, int) (sirius.DeputyEvents, error)
 }
 
 type deputyHubEventVars struct {
@@ -24,7 +24,7 @@ func renderTemplateForDeputyHubEvents(client DeputyHubEventInformation, tmpl Tem
 		}
 
 		ctx := getContext(r)
-		deputyEvents, err := client.GetDeputyEvents(ctx, deputyDetails)
+		deputyEvents, err := client.GetDeputyEvents(ctx, deputyDetails.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/server/deputy_events_test.go
+++ b/internal/server/deputy_events_test.go
@@ -16,7 +16,7 @@ type mockDeputyHubTimelineInformation struct {
 	deputyEvents sirius.DeputyEvents
 }
 
-func (m *mockDeputyHubTimelineInformation) GetDeputyEvents(ctx sirius.Context, deputyId sirius.DeputyDetails) (sirius.DeputyEvents, error) {
+func (m *mockDeputyHubTimelineInformation) GetDeputyEvents(ctx sirius.Context, deputyId int) (sirius.DeputyEvents, error) {
 	m.count += 1
 	m.lastCtx = ctx
 

--- a/internal/server/deputy_events_test.go
+++ b/internal/server/deputy_events_test.go
@@ -13,10 +13,10 @@ type mockDeputyHubTimelineInformation struct {
 	count        int
 	lastCtx      sirius.Context
 	err          error
-	deputyEvents sirius.DeputyEventCollection
+	deputyEvents sirius.DeputyEvents
 }
 
-func (m *mockDeputyHubTimelineInformation) GetDeputyEvents(ctx sirius.Context, deputyId int) (sirius.DeputyEventCollection, error) {
+func (m *mockDeputyHubTimelineInformation) GetDeputyEvents(ctx sirius.Context, deputyId sirius.DeputyDetails) (sirius.DeputyEvents, error) {
 	m.count += 1
 	m.lastCtx = ctx
 

--- a/internal/server/manage_assurance_visits_test.go
+++ b/internal/server/manage_assurance_visits_test.go
@@ -66,7 +66,7 @@ func TestGetManageAssurance(t *testing.T) {
 	visitRagRatingTypes := []sirius.VisitRagRatingTypes{{Handle: "x", Label: "y"}}
 	visitOutcomeTypes := []sirius.VisitOutcomeTypes{{Handle: "x", Label: "w"}}
 	pdrOutcomeTypes := []sirius.PdrOutcomeTypes{{Handle: "x", Label: "z"}}
-	visit := sirius.AssuranceVisit{Id: 1, RequestedDate: "2022-01-02", RequestedBy: sirius.User{UserId: 2}}
+	visit := sirius.AssuranceVisit{Id: 1, RequestedDate: "2022-01-02", RequestedBy: sirius.User{ID: 2}}
 
 	client := &mockManageAssuranceVisitInformation{}
 	client.On("GetAssuranceVisitById", mock.Anything, 0, 0).Return(visit, nil)
@@ -140,7 +140,7 @@ func TestGetManagePDR(t *testing.T) {
 	visitRagRatingTypes := []sirius.VisitRagRatingTypes{{Handle: "x", Label: "y"}}
 	visitOutcomeTypes := []sirius.VisitOutcomeTypes{{Handle: "x", Label: "w"}}
 	pdrOutcomeTypes := []sirius.PdrOutcomeTypes{{Handle: "x", Label: "z"}}
-	visit := sirius.AssuranceVisit{Id: 1, AssuranceType: sirius.AssuranceTypes{Handle: "PDR", Label: "PDR"}, RequestedDate: "2022-01-02", RequestedBy: sirius.User{UserId: 2}}
+	visit := sirius.AssuranceVisit{Id: 1, AssuranceType: sirius.AssuranceTypes{Handle: "PDR", Label: "PDR"}, RequestedDate: "2022-01-02", RequestedBy: sirius.User{ID: 2}}
 
 	client := &mockManageAssuranceVisitInformation{}
 	client.On("GetAssuranceVisitById", mock.Anything, 0, 0).Return(visit, nil)

--- a/internal/sirius/add_task.go
+++ b/internal/sirius/add_task.go
@@ -9,15 +9,17 @@ import (
 type addTask struct {
 	DeputyId   int    `json:"personId"`
 	TaskType   string `json:"type"`
+	TypeName   string `json:"name"`
 	DueDate    string `json:"dueDate"`
 	Notes      string `json:"description"`
 	AssigneeId int    `json:"assigneeId"`
 }
 
-func (c *Client) AddTask(ctx Context, deputyId int, taskType string, dueDate string, notes string, assigneeId int) error {
+func (c *Client) AddTask(ctx Context, deputyId int, taskType string, typeName string, dueDate string, notes string, assigneeId int) error {
 	var body bytes.Buffer
 	err := json.NewEncoder(&body).Encode(addTask{
 		TaskType:   taskType,
+		TypeName:   typeName,
 		DueDate:    FormatDateTime(IsoDate, dueDate, SiriusDate),
 		Notes:      notes,
 		AssigneeId: assigneeId,

--- a/internal/sirius/add_task_test.go
+++ b/internal/sirius/add_task_test.go
@@ -36,7 +36,7 @@ func TestTask(t *testing.T) {
 		}, nil
 	}
 
-	err := client.AddTask(getContext(nil), 1, "AAAA", "2022-04-02", "test note", 1)
+	err := client.AddTask(getContext(nil), 1, "AAAA", "", "2022-04-02", "test note", 1)
 	assert.Nil(t, err)
 }
 
@@ -49,7 +49,7 @@ func TestAddTaskReturnsNewStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, svr.URL)
 
-	err := client.AddTask(getContext(nil), 1, "AAAA", "2022-04-02", "test note", 1)
+	err := client.AddTask(getContext(nil), 1, "AAAA", "", "2022-04-02", "test note", 1)
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
@@ -66,7 +66,7 @@ func TestAddTaskReturnsUnauthorisedClientError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, svr.URL)
 
-	err := client.AddTask(getContext(nil), 1, "AAAA", "2022-04-02", "test note", 1)
+	err := client.AddTask(getContext(nil), 1, "AAAA", "", "2022-04-02", "test note", 1)
 
 	assert.Equal(t, ErrUnauthorized, err)
 }

--- a/internal/sirius/get_assurance_visit_test.go
+++ b/internal/sirius/get_assurance_visit_test.go
@@ -67,7 +67,7 @@ func TestAssuranceVisitReturned(t *testing.T) {
 		Id:                  3,
 		AssuranceType:       AssuranceTypes{Handle: "VISIT", Label: "Visit"},
 		RequestedDate:       "2022-06-25",
-		RequestedBy:         User{UserId: 53, UserDisplayName: "case manager"},
+		RequestedBy:         User{ID: 53, Name: "case manager"},
 		CommissionedDate:    "2022-01-01",
 		ReportDueDate:       "2022-01-07",
 		ReportReceivedDate:  "2022-01-07",
@@ -77,7 +77,7 @@ func TestAssuranceVisitReturned(t *testing.T) {
 		VisitReportMarkedAs: VisitRagRatingTypes{Label: "Red", Handle: "RED"},
 		Note:                "This is just to see the notes and it is below 1000 characters",
 		VisitorAllocated:    "Jane Janeson",
-		ReviewedBy:          User{UserId: 53, UserDisplayName: "case manager"},
+		ReviewedBy:          User{ID: 53, Name: "case manager"},
 	}
 
 	assuranceVisit, err := client.GetAssuranceVisitById(getContext(nil), 76, 3)

--- a/internal/sirius/get_assurance_visits_test.go
+++ b/internal/sirius/get_assurance_visits_test.go
@@ -103,7 +103,7 @@ func TestAssuranceVisitsReturned(t *testing.T) {
 			VisitId:             3,
 			AssuranceType:       AssuranceTypes{Handle: "VISIT", Label: "Visit"},
 			RequestedDate:       "25/06/2022",
-			RequestedBy:         User{UserId: 53, UserDisplayName: "case manager"},
+			RequestedBy:         User{ID: 53, Name: "case manager"},
 			DeputyId:            1,
 			CommissionedDate:    "01/01/2022",
 			ReportDueDate:       "07/01/2022",
@@ -113,13 +113,13 @@ func TestAssuranceVisitsReturned(t *testing.T) {
 			VisitReportMarkedAs: VisitRagRatingTypes{Label: "Red", Handle: "RED"},
 			Note:                "This is just notes for something to show",
 			VisitorAllocated:    "Jane Janeson",
-			ReviewedBy:          User{UserId: 53, UserDisplayName: "case manager"},
+			ReviewedBy:          User{ID: 53, Name: "case manager"},
 		},
 		{
 			VisitId:             4,
 			AssuranceType:       AssuranceTypes{Handle: "PDR", Label: "PDR"},
 			RequestedDate:       "25/06/2022",
-			RequestedBy:         User{UserId: 53, UserDisplayName: "case manager"},
+			RequestedBy:         User{ID: 53, Name: "case manager"},
 			DeputyId:            1,
 			CommissionedDate:    "01/01/2022",
 			ReportDueDate:       "07/01/2022",
@@ -129,7 +129,7 @@ func TestAssuranceVisitsReturned(t *testing.T) {
 			VisitReportMarkedAs: VisitRagRatingTypes{Label: "Red", Handle: "RED"},
 			Note:                "",
 			VisitorAllocated:    "Jane Janeson",
-			ReviewedBy:          User{UserId: 53, UserDisplayName: "case manager"},
+			ReviewedBy:          User{ID: 53, Name: "case manager"},
 		},
 	}
 

--- a/internal/sirius/get_deputy_events.go
+++ b/internal/sirius/get_deputy_events.go
@@ -9,12 +9,12 @@ import (
 	"time"
 )
 
-type DeputyEventCollection []DeputyEvent
+type DeputyEvents []DeputyEvent
 
 type User struct {
-	UserId          int    `json:"id"`
-	UserDisplayName string `json:"displayName"`
-	UserPhoneNumber string `json:"phoneNumber"`
+	ID          int    `json:"id"`
+	Name        string `json:"displayName"`
+	PhoneNumber string `json:"phoneNumber"`
 }
 
 type Event struct {
@@ -37,6 +37,10 @@ type Event struct {
 	VisitReportMarkedAs  string         `json:"assuranceVisitReportMarkedAs"`
 	VisitorAllocated     string         `json:"visitorAllocated"`
 	ReviewedBy           string         `json:"reviewedBy"`
+	TaskType             string         `json:"taskType"`
+	Assignee             string         `json:"assignee"`
+	DueDate              string         `json:"dueDate"`
+	Notes                string         `json:"description"`
 }
 
 type Changes struct {
@@ -46,94 +50,116 @@ type Changes struct {
 }
 
 type ClientPerson struct {
-	ClientName     string `json:"personName"`
-	ClientId       string `json:"personId"`
-	ClientUid      string `json:"personUid"`
-	ClientCourtRef string `json:"personCourtRef"`
+	ID       string `json:"personId"`
+	Uid      string `json:"personUid"`
+	Name     string `json:"personName"`
+	CourtRef string `json:"personCourtRef"`
 }
 
 type DeputyEvent struct {
-	TimelineEventId int    `json:"id"`
-	Timestamp       string `json:"timestamp"`
-	EventType       string `json:"eventType"`
-	User            User   `json:"user"`
-	Event           Event  `json:"event"`
-	IsNewEvent      bool
+	ID         int    `json:"id"`
+	Timestamp  string `json:"timestamp"`
+	EventType  string `json:"eventType"`
+	User       User   `json:"user"`
+	Event      Event  `json:"event"`
+	IsNewEvent bool
 }
 
-func (c *Client) GetDeputyEvents(ctx Context, deputyId int) (DeputyEventCollection, error) {
-	var v DeputyEventCollection
+func (c *Client) GetDeputyEvents(ctx Context, deputyId int) (DeputyEvents, error) {
+	var de DeputyEvents
 
 	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/timeline/%d", deputyId), nil)
 
 	if err != nil {
-		return v, err
+		return de, err
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return v, err
+		return de, err
 	}
 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return v, ErrUnauthorized
+		return de, ErrUnauthorized
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return v, newStatusError(resp)
+		return de, newStatusError(resp)
 	}
-	err = json.NewDecoder(resp.Body).Decode(&v)
+	err = json.NewDecoder(resp.Body).Decode(&de)
 
-	DeputyEvents := editDeputyEvents(v)
+	var (
+		taskTypes TaskTypeMap
+		terr      error
+	)
+	if includesTaskEvent(de) {
+		taskTypes, terr = c.getTaskTypesMap(ctx)
+		if terr != nil {
+			return nil, terr
+		}
+	}
+
+	DeputyEvents := editDeputyEvents(de, taskTypes)
 
 	return DeputyEvents, err
 
 }
 
-func editDeputyEvents(v DeputyEventCollection) DeputyEventCollection {
-	var list DeputyEventCollection
-	for _, s := range v {
+func editDeputyEvents(events DeputyEvents, taskTypes TaskTypeMap) DeputyEvents {
+	var list DeputyEvents
+	for _, e := range events {
 		event := DeputyEvent{
-			Timestamp:       FormatDateTime(IsoDateTime, s.Timestamp, SiriusDateTime),
-			EventType:       reformatEventType(s.EventType),
-			TimelineEventId: s.TimelineEventId,
-			User:            s.User,
-			Event:           s.Event,
-			IsNewEvent:      calculateIfNewEvent(s.Event.Changes),
+			Timestamp:  FormatDateTime(IsoDateTime, e.Timestamp, SiriusDateTime),
+			EventType:  reformatEventType(e.EventType),
+			ID:         e.ID,
+			User:       e.User,
+			Event:      updateTaskInfo(e.Event, taskTypes),
+			IsNewEvent: isNewEvent(e.Event.Changes),
 		}
 
 		list = append(list, event)
 	}
-	sortTimeLineNewestOneFirst(list)
+	sortByTimelineAsc(list)
 	return list
 }
 
-func calculateIfNewEvent(changes []Changes) bool {
-	var answer bool
-	for _, s := range changes {
-		if s.OldValue != "" {
-			answer = false
-		} else {
-			answer = true
-		}
+func isNewEvent(changes []Changes) bool {
+	var isNew bool
+	for _, c := range changes {
+		isNew = c.OldValue == ""
 	}
-	return answer
+	return isNew
 }
 
 func reformatEventType(s string) string {
 	eventTypeArray := strings.Split(s, "\\")
-	eventTypeArrayLength := len(eventTypeArray)
-	eventTypeName := eventTypeArray[eventTypeArrayLength-1]
-	return eventTypeName
+	return eventTypeArray[len(eventTypeArray)-1]
 }
 
-func sortTimeLineNewestOneFirst(v DeputyEventCollection) DeputyEventCollection {
-	sort.Slice(v, func(i, j int) bool {
-		changeToTimeTypeI, _ := time.Parse(SiriusDateTime, v[i].Timestamp)
-		changeToTimeTypeJ, _ := time.Parse(SiriusDateTime, v[j].Timestamp)
-		return changeToTimeTypeJ.Before(changeToTimeTypeI)
+func sortByTimelineAsc(events DeputyEvents) DeputyEvents {
+	sort.Slice(events, func(i, j int) bool {
+		iTime, _ := time.Parse(SiriusDateTime, events[i].Timestamp)
+		jTime, _ := time.Parse(SiriusDateTime, events[j].Timestamp)
+		return jTime.Before(iTime)
 	})
-	return v
+	return events
+}
+
+func includesTaskEvent(events DeputyEvents) bool {
+	for _, e := range events {
+		if e.Event.TaskType > "" {
+			return true
+		}
+	}
+	return false
+}
+
+func updateTaskInfo(event Event, taskTypes TaskTypeMap) Event {
+	if event.TaskType > "" {
+		event.TaskType = taskTypes[event.TaskType].Description
+		event.DueDate = FormatDateTime(IsoDateTime, event.DueDate, SiriusDate)
+	}
+	return event
 }

--- a/internal/sirius/get_deputy_events_test.go
+++ b/internal/sirius/get_deputy_events_test.go
@@ -2,7 +2,6 @@ package sirius
 
 import (
 	"bytes"
-	"github.com/ministryofjustice/opg-sirius-supervision-deputy-hub/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
@@ -14,69 +13,148 @@ func AmendDateForDST(date string) string {
 	return FormatDateTime(SiriusDateTime, date, SiriusDateTime)
 }
 
+type mockEventClient struct {
+	responses []io.ReadCloser
+	count     int
+}
+
+func (m *mockEventClient) Do(*http.Request) (*http.Response, error) {
+	m.count++
+	return &http.Response{
+		StatusCode: 200,
+		Body:       m.responses[m.count-1],
+	}, nil
+}
+
 func TestDeputyEventsReturned(t *testing.T) {
-	mockClient := &mocks.MockClient{}
-	client, _ := NewClient(mockClient, "http://localhost:3000")
+	mockClient := mockEventClient{}
+	client, _ := NewClient(&mockClient, "http://localhost:3000")
 
-	json := `[
-   {
-     "id": 300,
-     "hash": "AW",
-     "timestamp": "2021-09-09 14:01:59",
-     "eventType": "Opg\\Core\\Model\\Event\\Order\\DeputyLinkedToOrder",
-     "user": {
-       "id": 41,
-       "phoneNumber": "12345678",
-       "displayName": "system admin",
-       "email": "system.admin@opgtest.com"
-     },
-     "event": {
-       "orderType": "pfa",
-       "orderUid": "7000-0000-1995",
-       "orderId": "58",
-       "orderCourtRef": "03305972",
-       "courtReferenceNumber": "03305972",
-       "courtReference": "03305972",
-       "personType": "Deputy",
-       "personId": "76",
-       "personUid": "7000-0000-2530",
-       "personName": "Mx Bob Builder",
-       "personCourtRef": null,
-       "additionalPersons": [
-         {
-           "personType": "Client",
-           "personId": "63",
-           "personUid": "7000-0000-1961",
-           "personName": "Test Name",
-           "personCourtRef": "40124126"
-         }
-       ]
-     }
-   }
- ]`
+	eventJson := `
+	[
+	  {
+		"id": 300,
+		"hash": "AW",
+		"timestamp": "2021-09-09 14:01:59",
+		"eventType": "Opg\\Core\\Model\\Event\\Order\\DeputyLinkedToOrder",
+		"user": {
+		  "id": 41,
+		  "phoneNumber": "12345678",
+		  "displayName": "system admin",
+		  "email": "system.admin@opgtest.com"
+		},
+		"event": {
+		  "orderType": "pfa",
+		  "orderUid": "7000-0000-1995",
+		  "orderId": "58",
+		  "orderCourtRef": "03305972",
+		  "courtReferenceNumber": "03305972",
+		  "courtReference": "03305972",
+		  "personType": "Deputy",
+		  "personId": "76",
+		  "personUid": "7000-0000-2530",
+		  "personName": "Mx Bob Builder",
+		  "personCourtRef": null,
+		  "additionalPersons": [
+			{
+			  "personType": "Client",
+			  "personId": "63",
+			  "personUid": "7000-0000-1961",
+			  "personName": "Test Name",
+			  "personCourtRef": "40124126"
+			}
+		  ]
+		}
+	  },
+	  {
+		"id": 397,
+		"hash": "AY",
+		"timestamp": "2021-01-10 15:01:59",
+		"eventType": "Opg\\Core\\Model\\Event\\Common\\TaskCreated",
+		"user": {
+		  "id": 21,
+		  "phoneNumber": "0123456789",
+		  "displayName": "Lay Team 1 - (Supervision)",
+		  "email": "LayTeam1.team@opgtest.com"
+		},
+		"event": {
+			"isCaseEvent": false,
+			"isPersonEvent": true,
+			"taskId": 249,
+			"taskType": "AVFU",
+			"dueDate": "2023-07-13 00:00:00",
+			"description": "This is a note",
+			"name": "",
+			"assigneeId": "28",
+			"assignee": "PA Team Workflow",
+			"isCaseOwnerTask": false,
+			"personType": "Deputy",
+			"personId": "78",
+			"personUid": "7000-0000-2530",
+			"personName": "Bobby Deputiser"
+		  }
+	  }
+	]
+	`
+	taskTypesJson := `
+	{
+            "task_types": {
+                "SAP": {
+                    "handle": "SAP",
+                    "incomplete": "Start Assurance process",
+                    "complete": "Start Assurance process",
+                    "user": true,
+                    "category": "deputy",
+                    "ecmTask": false,
+                    "proDeputyTask": true,
+                    "paDeputyTask": false
+                },
+                "AVFU": {
+                    "handle": "AVFU",
+                    "incomplete": "Assurance visit follow up",
+                    "complete": "Assurance visit follow up",
+                    "user": true,
+                    "category": "deputy",
+                    "ecmTask": false,
+                    "proDeputyTask": true,
+                    "paDeputyTask": true
+                }
+            }
+        }
+	`
 
-	r := io.NopCloser(bytes.NewReader([]byte(json)))
+	mockClient.responses = append(
+		mockClient.responses,
+		io.NopCloser(bytes.NewReader([]byte(eventJson))),
+		io.NopCloser(bytes.NewReader([]byte(taskTypesJson))))
 
-	mocks.GetDoFunc = func(*http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: 200,
-			Body:       r,
-		}, nil
-	}
-
-	expectedResponse := DeputyEventCollection{
+	expectedResponse := DeputyEvents{
 		DeputyEvent{
-			TimelineEventId: 300,
-			Timestamp:       AmendDateForDST("09/09/2021 14:01:59"),
-			EventType:       "DeputyLinkedToOrder",
-			User:            User{UserId: 41, UserDisplayName: "system admin", UserPhoneNumber: "12345678"},
+			ID:        300,
+			Timestamp: AmendDateForDST("09/09/2021 14:01:59"),
+			EventType: "DeputyLinkedToOrder",
+			User:      User{ID: 41, Name: "system admin", PhoneNumber: "12345678"},
 			Event: Event{
 				DeputyID:    "76",
 				DeputyName:  "Mx Bob Builder",
 				OrderType:   "pfa",
 				SiriusId:    "7000-0000-1995",
 				OrderNumber: "03305972",
-				Client:      []ClientPerson{{ClientName: "Test Name", ClientId: "63", ClientUid: "7000-0000-1961", ClientCourtRef: "40124126"}},
+				Client:      []ClientPerson{{Name: "Test Name", ID: "63", Uid: "7000-0000-1961", CourtRef: "40124126"}},
+			},
+		},
+		DeputyEvent{
+			ID:        397,
+			Timestamp: AmendDateForDST("10/01/2021 15:01:59"),
+			EventType: "TaskCreated",
+			User:      User{ID: 21, Name: "Lay Team 1 - (Supervision)", PhoneNumber: "0123456789"},
+			Event: Event{
+				DeputyID:   "78",
+				DeputyName: "Bobby Deputiser",
+				TaskType:   "Assurance visit follow up",
+				Assignee:   "PA Team Workflow",
+				DueDate:    "13/07/2023",
+				Notes:      "This is a note",
 			},
 		},
 	}
@@ -97,7 +175,7 @@ func TestGetDeputyEventsReturnsNewStatusError(t *testing.T) {
 
 	deputyEvents, err := client.GetDeputyEvents(getContext(nil), 76)
 
-	expectedResponse := DeputyEventCollection(nil)
+	expectedResponse := DeputyEvents(nil)
 
 	assert.Equal(t, expectedResponse, deputyEvents)
 	assert.Equal(t, StatusError{
@@ -117,7 +195,7 @@ func TestGetDeputyEventsReturnsUnauthorisedClientError(t *testing.T) {
 
 	deputyEvents, err := client.GetDeputyEvents(getContext(nil), 76)
 
-	expectedResponse := DeputyEventCollection(nil)
+	expectedResponse := DeputyEvents(nil)
 
 	assert.Equal(t, ErrUnauthorized, err)
 	assert.Equal(t, expectedResponse, deputyEvents)
@@ -129,262 +207,64 @@ func TestReformatEventType(t *testing.T) {
 	assert.Equal(t, expectedResponse, reformatEventType(testDeputyEvent))
 }
 
-func TestSortTimeLineNewestOneFirst(t *testing.T) {
-	unsortedData := DeputyEventCollection{
+func TestSortByTimelineAsc(t *testing.T) {
+	unsortedData := DeputyEvents{
 		DeputyEvent{
-			TimelineEventId: 388,
-			Timestamp:       "19/10/2020 10:12:08",
-			EventType:       "PersonContactDetailsChanged",
-			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
-			},
-			Event: Event{
-				OrderType:        "null",
-				SiriusId:         "null",
-				OrderNumber:      "null",
-				DeputyID:         "76",
-				DeputyName:       "null",
-				OrganisationName: "null",
-				Changes: []Changes{
-					{
-						FieldName: "mobileNumber",
-						OldValue:  "null",
-						NewValue:  "null",
-					},
-					{
-						FieldName: "homePhoneNumber",
-						OldValue:  "null",
-						NewValue:  "null",
-					},
-				},
-				Client: []ClientPerson{},
-			},
+			ID:        388,
+			Timestamp: "19/10/2020 10:12:08",
+			EventType: "PersonContactDetailsChanged",
 		},
 		DeputyEvent{
-			TimelineEventId: 387,
-			Timestamp:       "18/10/2020 10:12:08",
-			EventType:       "PaDetailsChanged",
-			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
-			},
-			Event: Event{
-				OrderType:        "null",
-				SiriusId:         "null",
-				OrderNumber:      "null",
-				DeputyID:         "76",
-				DeputyName:       "null",
-				OrganisationName: "null",
-				Changes: []Changes{
-					{
-						FieldName: "Deputy name",
-						OldValue:  "null",
-						NewValue:  "PaDeputy",
-					},
-					{
-						FieldName: "Telephone",
-						OldValue:  "null",
-						NewValue:  "null",
-					},
-					{
-						FieldName: "Email",
-						OldValue:  "null",
-						NewValue:  "null",
-					},
-					{
-						FieldName: "Teamordepartmentname",
-						OldValue:  "null",
-						NewValue:  "PA Team 1 - (Supervision)",
-					},
-				},
-				Client: []ClientPerson{},
-			},
+			ID:        387,
+			Timestamp: "18/10/2020 10:12:08",
+			EventType: "PaDetailsChanged",
 		},
 		DeputyEvent{
-			TimelineEventId: 390,
-			Timestamp:       "20/09/2020 10:11:08",
-			EventType:       "DeputyLinkedToOrder",
-			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
-			},
-			Event: Event{
-				OrderType:        "pfa",
-				SiriusId:         "7000-0000-2381",
-				OrderNumber:      "18372470",
-				DeputyID:         "76",
-				DeputyName:       "null",
-				OrganisationName: "null",
-				Changes:          []Changes{},
-				Client: []ClientPerson{
-					{
-						ClientName:     "Duke John Fearless",
-						ClientId:       "72",
-						ClientUid:      "7000-0000-2357",
-						ClientCourtRef: "2001022T",
-					},
-				},
-			},
+			ID:        390,
+			Timestamp: "20/09/2020 10:11:08",
+			EventType: "DeputyLinkedToOrder",
 		},
 		DeputyEvent{
-			TimelineEventId: 389,
-			Timestamp:       "16/10/2020 10:11:08",
-			EventType:       "PADeputyCreated",
-			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
-			},
-			Event: Event{
-				OrderType:        "null",
-				SiriusId:         "null",
-				OrderNumber:      "null",
-				DeputyID:         "76",
-				DeputyName:       "null",
-				OrganisationName: "null",
-				Changes:          []Changes{},
-				Client:           []ClientPerson{},
-			},
+			ID:        389,
+			Timestamp: "16/10/2020 10:11:08",
+			EventType: "PADeputyCreated",
 		},
 	}
-	expectedResponse := DeputyEventCollection{
+	expectedResponse := DeputyEvents{
 		DeputyEvent{
-			TimelineEventId: 388,
-			Timestamp:       "19/10/2020 10:12:08",
-			EventType:       "PersonContactDetailsChanged",
-			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
-			},
-			Event: Event{
-				OrderType:        "null",
-				SiriusId:         "null",
-				OrderNumber:      "null",
-				DeputyID:         "76",
-				DeputyName:       "null",
-				OrganisationName: "null",
-				Changes: []Changes{
-					{
-						FieldName: "mobileNumber",
-						OldValue:  "null",
-						NewValue:  "null",
-					},
-					{
-						FieldName: "homePhoneNumber",
-						OldValue:  "null",
-						NewValue:  "null",
-					},
-				},
-				Client: []ClientPerson{},
-			},
+			ID:        388,
+			Timestamp: "19/10/2020 10:12:08",
+			EventType: "PersonContactDetailsChanged",
 		},
 		DeputyEvent{
-			TimelineEventId: 387,
-			Timestamp:       "18/10/2020 10:12:08",
-			EventType:       "PaDetailsChanged",
-			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
-			},
-			Event: Event{
-				OrderType:        "null",
-				SiriusId:         "null",
-				OrderNumber:      "null",
-				DeputyID:         "76",
-				DeputyName:       "null",
-				OrganisationName: "null",
-				Changes: []Changes{
-					{
-						FieldName: "Deputy name",
-						OldValue:  "null",
-						NewValue:  "PaDeputy",
-					},
-					{
-						FieldName: "Telephone",
-						OldValue:  "null",
-						NewValue:  "null",
-					},
-					{
-						FieldName: "Email",
-						OldValue:  "null",
-						NewValue:  "null",
-					},
-					{
-						FieldName: "Teamordepartmentname",
-						OldValue:  "null",
-						NewValue:  "PA Team 1 - (Supervision)",
-					},
-				},
-				Client: []ClientPerson{},
-			},
+			ID:        387,
+			Timestamp: "18/10/2020 10:12:08",
+			EventType: "PaDetailsChanged",
 		},
 		DeputyEvent{
-			TimelineEventId: 389,
-			Timestamp:       "16/10/2020 10:11:08",
-			EventType:       "PADeputyCreated",
-			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
-			},
-			Event: Event{
-				OrderType:        "null",
-				SiriusId:         "null",
-				OrderNumber:      "null",
-				DeputyID:         "76",
-				DeputyName:       "null",
-				OrganisationName: "null",
-				Changes:          []Changes{},
-				Client:           []ClientPerson{},
-			},
+			ID:        389,
+			Timestamp: "16/10/2020 10:11:08",
+			EventType: "PADeputyCreated",
 		},
 		DeputyEvent{
-			TimelineEventId: 390,
-			Timestamp:       "20/09/2020 10:11:08",
-			EventType:       "DeputyLinkedToOrder",
-			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
-			},
-			Event: Event{
-				OrderType:        "pfa",
-				SiriusId:         "7000-0000-2381",
-				OrderNumber:      "18372470",
-				DeputyID:         "76",
-				DeputyName:       "null",
-				OrganisationName: "null",
-				Changes:          []Changes{},
-				Client: []ClientPerson{
-					{
-						ClientName:     "Duke John Fearless",
-						ClientId:       "72",
-						ClientUid:      "7000-0000-2357",
-						ClientCourtRef: "2001022T",
-					},
-				},
-			},
+			ID:        390,
+			Timestamp: "20/09/2020 10:11:08",
+			EventType: "DeputyLinkedToOrder",
 		},
 	}
-	assert.Equal(t, expectedResponse, sortTimeLineNewestOneFirst(unsortedData))
+	assert.Equal(t, expectedResponse, sortByTimelineAsc(unsortedData))
 }
 
 func TestEditDeputyEvents(t *testing.T) {
-	unsortedData := DeputyEventCollection{
+	unsortedData := DeputyEvents{
 		DeputyEvent{
-			TimelineEventId: 388,
-			Timestamp:       "2020-10-18 10:11:08",
-			EventType:       "Opg\\Core\\Model\\Event\\Order\\PersonContactDetailsChanged",
+			ID:        388,
+			Timestamp: "2020-10-18 10:11:08",
+			EventType: "Opg\\Core\\Model\\Event\\Order\\PersonContactDetailsChanged",
 			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
+				ID:          51,
+				Name:        "case manager",
+				PhoneNumber: "12345678",
 			},
 			Event: Event{
 				OrderType:        "null",
@@ -409,13 +289,13 @@ func TestEditDeputyEvents(t *testing.T) {
 			},
 		},
 		DeputyEvent{
-			TimelineEventId: 387,
-			Timestamp:       "2020-10-18 11:12:08",
-			EventType:       "Opg\\Core\\Model\\Event\\Order\\PaDetailsChanged",
+			ID:        387,
+			Timestamp: "2020-10-18 11:12:08",
+			EventType: "Opg\\Core\\Model\\Event\\Order\\PaDetailsChanged",
 			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
+				ID:          51,
+				Name:        "case manager",
+				PhoneNumber: "12345678",
 			},
 			Event: Event{
 				OrderType:        "null",
@@ -450,13 +330,13 @@ func TestEditDeputyEvents(t *testing.T) {
 			},
 		},
 		DeputyEvent{
-			TimelineEventId: 390,
-			Timestamp:       "2020-09-20 10:11:08",
-			EventType:       "Opg\\Core\\Model\\Event\\Order\\DeputyLinkedToOrder",
+			ID:        390,
+			Timestamp: "2020-09-20 10:11:08",
+			EventType: "Opg\\Core\\Model\\Event\\Order\\DeputyLinkedToOrder",
 			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
+				ID:          51,
+				Name:        "case manager",
+				PhoneNumber: "12345678",
 			},
 			Event: Event{
 				OrderType:        "pfa",
@@ -468,22 +348,22 @@ func TestEditDeputyEvents(t *testing.T) {
 				Changes:          []Changes{},
 				Client: []ClientPerson{
 					{
-						ClientName:     "Duke John Fearless",
-						ClientId:       "72",
-						ClientUid:      "7000-0000-2357",
-						ClientCourtRef: "2001022T",
+						Name:     "Duke John Fearless",
+						ID:       "72",
+						Uid:      "7000-0000-2357",
+						CourtRef: "2001022T",
 					},
 				},
 			},
 		},
 		DeputyEvent{
-			TimelineEventId: 389,
-			Timestamp:       "2020-10-16 10:11:08",
-			EventType:       "Opg\\Core\\Model\\Event\\Order\\PADeputyCreated",
+			ID:        389,
+			Timestamp: "2020-10-16 10:11:08",
+			EventType: "Opg\\Core\\Model\\Event\\Order\\PADeputyCreated",
 			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
+				ID:          51,
+				Name:        "case manager",
+				PhoneNumber: "12345678",
 			},
 			Event: Event{
 				OrderType:        "null",
@@ -497,15 +377,15 @@ func TestEditDeputyEvents(t *testing.T) {
 			},
 		},
 	}
-	expectedResponse := DeputyEventCollection{
+	expectedResponse := DeputyEvents{
 		DeputyEvent{
-			TimelineEventId: 387,
-			Timestamp:       AmendDateForDST("18/10/2020 11:12:08"),
-			EventType:       "PaDetailsChanged",
+			ID:        387,
+			Timestamp: AmendDateForDST("18/10/2020 11:12:08"),
+			EventType: "PaDetailsChanged",
 			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
+				ID:          51,
+				Name:        "case manager",
+				PhoneNumber: "12345678",
 			},
 			Event: Event{
 				OrderType:        "null",
@@ -540,13 +420,13 @@ func TestEditDeputyEvents(t *testing.T) {
 			},
 		},
 		DeputyEvent{
-			TimelineEventId: 388,
-			Timestamp:       AmendDateForDST("18/10/2020 10:11:08"),
-			EventType:       "PersonContactDetailsChanged",
+			ID:        388,
+			Timestamp: AmendDateForDST("18/10/2020 10:11:08"),
+			EventType: "PersonContactDetailsChanged",
 			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
+				ID:          51,
+				Name:        "case manager",
+				PhoneNumber: "12345678",
 			},
 			Event: Event{
 				OrderType:        "null",
@@ -571,13 +451,13 @@ func TestEditDeputyEvents(t *testing.T) {
 			},
 		},
 		DeputyEvent{
-			TimelineEventId: 389,
-			Timestamp:       AmendDateForDST("16/10/2020 10:11:08"),
-			EventType:       "PADeputyCreated",
+			ID:        389,
+			Timestamp: AmendDateForDST("16/10/2020 10:11:08"),
+			EventType: "PADeputyCreated",
 			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
+				ID:          51,
+				Name:        "case manager",
+				PhoneNumber: "12345678",
 			},
 			Event: Event{
 				OrderType:        "null",
@@ -591,13 +471,13 @@ func TestEditDeputyEvents(t *testing.T) {
 			},
 		},
 		DeputyEvent{
-			TimelineEventId: 390,
-			Timestamp:       AmendDateForDST("20/09/2020 10:11:08"),
-			EventType:       "DeputyLinkedToOrder",
+			ID:        390,
+			Timestamp: AmendDateForDST("20/09/2020 10:11:08"),
+			EventType: "DeputyLinkedToOrder",
 			User: User{
-				UserId:          51,
-				UserDisplayName: "case manager",
-				UserPhoneNumber: "12345678",
+				ID:          51,
+				Name:        "case manager",
+				PhoneNumber: "12345678",
 			},
 			Event: Event{
 				OrderType:        "pfa",
@@ -609,19 +489,19 @@ func TestEditDeputyEvents(t *testing.T) {
 				Changes:          []Changes{},
 				Client: []ClientPerson{
 					{
-						ClientName:     "Duke John Fearless",
-						ClientId:       "72",
-						ClientUid:      "7000-0000-2357",
-						ClientCourtRef: "2001022T",
+						Name:     "Duke John Fearless",
+						ID:       "72",
+						Uid:      "7000-0000-2357",
+						CourtRef: "2001022T",
 					},
 				},
 			},
 		},
 	}
-	assert.Equal(t, expectedResponse, editDeputyEvents(unsortedData))
+	assert.Equal(t, expectedResponse, editDeputyEvents(unsortedData, TaskTypeMap{}))
 }
-func TestCalculateIfNewEvent(t *testing.T) {
-	assert.Equal(t, true, calculateIfNewEvent(
+func TestIsNewEvent(t *testing.T) {
+	assert.Equal(t, true, isNewEvent(
 		[]Changes{
 			{
 				FieldName: "firm",
@@ -632,7 +512,7 @@ func TestCalculateIfNewEvent(t *testing.T) {
 				NewValue:  "1000028",
 			},
 		}))
-	assert.Equal(t, false, calculateIfNewEvent(
+	assert.Equal(t, false, isNewEvent(
 		[]Changes{
 			{
 				FieldName: "firm",

--- a/internal/sirius/get_task_types.go
+++ b/internal/sirius/get_task_types.go
@@ -13,11 +13,35 @@ type TaskType struct {
 	PaDeputyTask  bool   `json:"paDeputyTask"`
 }
 
-type TaskTypesMap struct {
-	TaskTypes map[string]TaskType `json:"task_types"`
+type TaskTypeMap map[string]TaskType
+
+type TaskTypes struct {
+	TaskTypes TaskTypeMap `json:"task_types"`
 }
 
-func (c *Client) GetTaskTypes(ctx Context, deputy DeputyDetails) ([]TaskType, error) {
+func (c *Client) GetTaskTypesForDeputyType(ctx Context, deputyType string) ([]TaskType, error) {
+	taskTypes, err := c.getTaskTypesMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var deputyTaskTypes []TaskType
+	for _, t := range taskTypes {
+		if t.ProDeputyTask && deputyType == "PRO" {
+			deputyTaskTypes = append(deputyTaskTypes, t)
+		} else if t.PaDeputyTask && deputyType == "PA" {
+			deputyTaskTypes = append(deputyTaskTypes, t)
+		}
+	}
+
+	sort.Slice(deputyTaskTypes, func(i, j int) bool {
+		return deputyTaskTypes[i].Handle < deputyTaskTypes[j].Handle
+	})
+
+	return deputyTaskTypes, err
+}
+
+func (c *Client) getTaskTypesMap(ctx Context) (TaskTypeMap, error) {
 	req, err := c.newRequest(ctx, http.MethodGet, "/api/v1/tasktypes/deputy", nil)
 
 	if err != nil {
@@ -39,25 +63,8 @@ func (c *Client) GetTaskTypes(ctx Context, deputy DeputyDetails) ([]TaskType, er
 		return nil, newStatusError(resp)
 	}
 
-	var taskTypes TaskTypesMap
-	if err = json.NewDecoder(resp.Body).Decode(&taskTypes); err != nil {
-		return nil, err
-	}
+	var taskTypes TaskTypes
+	err = json.NewDecoder(resp.Body).Decode(&taskTypes)
 
-	isPro := deputy.DeputyType.Handle == "PRO"
-
-	var deputyTaskTypes []TaskType
-	for _, t := range taskTypes.TaskTypes {
-		if t.ProDeputyTask && isPro {
-			deputyTaskTypes = append(deputyTaskTypes, t)
-		} else if t.PaDeputyTask && !isPro {
-			deputyTaskTypes = append(deputyTaskTypes, t)
-		}
-	}
-
-	sort.Slice(deputyTaskTypes, func(i, j int) bool {
-		return deputyTaskTypes[i].Handle < deputyTaskTypes[j].Handle
-	})
-
-	return deputyTaskTypes, err
+	return taskTypes.TaskTypes, err
 }

--- a/internal/sirius/get_task_types_test.go
+++ b/internal/sirius/get_task_types_test.go
@@ -21,7 +21,7 @@ var (
     }`
 )
 
-func TestGetTaskTypes_PA(t *testing.T) {
+func TestGetTaskTypes_PRO(t *testing.T) {
 	mockClient := &mocks.MockClient{}
 	client, _ := NewClient(mockClient, "http://localhost:3000")
 
@@ -32,10 +32,6 @@ func TestGetTaskTypes_PA(t *testing.T) {
 			StatusCode: 200,
 			Body:       r,
 		}, nil
-	}
-
-	deputy := DeputyDetails{
-		DeputyType: DeputyType{Handle: "PRO"},
 	}
 
 	expectedResponse := []TaskType{
@@ -52,13 +48,13 @@ func TestGetTaskTypes_PA(t *testing.T) {
 		},
 	}
 
-	taskTypes, err := client.GetTaskTypes(getContext(nil), deputy)
+	taskTypes, err := client.GetTaskTypesForDeputyType(getContext(nil), "PRO")
 
 	assert.Equal(t, expectedResponse, taskTypes)
 	assert.Equal(t, nil, err)
 }
 
-func TestGetTaskTypes_PRO(t *testing.T) {
+func TestGetTaskTypes_PA(t *testing.T) {
 	mockClient := &mocks.MockClient{}
 	client, _ := NewClient(mockClient, "http://localhost:3000")
 
@@ -69,10 +65,6 @@ func TestGetTaskTypes_PRO(t *testing.T) {
 			StatusCode: 200,
 			Body:       r,
 		}, nil
-	}
-
-	deputy := DeputyDetails{
-		DeputyType: DeputyType{Handle: "PA"},
 	}
 
 	expectedResponse := []TaskType{
@@ -89,7 +81,7 @@ func TestGetTaskTypes_PRO(t *testing.T) {
 		},
 	}
 
-	taskTypes, err := client.GetTaskTypes(getContext(nil), deputy)
+	taskTypes, err := client.GetTaskTypesForDeputyType(getContext(nil), "PA")
 
 	assert.Equal(t, expectedResponse, taskTypes)
 	assert.Equal(t, nil, err)
@@ -103,7 +95,7 @@ func TestGetTaskTypes_statusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, svr.URL)
 
-	taskTypes, err := client.GetTaskTypes(getContext(nil), DeputyDetails{})
+	taskTypes, err := client.GetTaskTypesForDeputyType(getContext(nil), "PRO")
 
 	assert.Equal(t, []TaskType(nil), taskTypes)
 	assert.Equal(t, StatusError{
@@ -121,7 +113,7 @@ func TestGetTaskTypes_unauthorised(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, svr.URL)
 
-	taskTypes, err := client.GetTaskTypes(getContext(nil), DeputyDetails{})
+	taskTypes, err := client.GetTaskTypesForDeputyType(getContext(nil), "PRO")
 
 	assert.Equal(t, ErrUnauthorized, err)
 	assert.Equal(t, []TaskType(nil), taskTypes)

--- a/json-server/config/custom-body-mapper.js
+++ b/json-server/config/custom-body-mapper.js
@@ -21,6 +21,6 @@ module.exports = (req, res, next) => {
 };
 
 const getUser = (req) => {
-    return req.headers?.cookie?.match(/user=(?<user>[^;]+);/)
+    return req.headers?.cookie?.match(/user=(?<user>[^;]+);?/)
         ?.groups.user;
 };

--- a/json-server/config/db.js
+++ b/json-server/config/db.js
@@ -1626,24 +1626,50 @@ module.exports = function () {
                 },
                 "event": {
                     "class": "Opg\\Core\\Model\\Event\\Deputy\\AssuranceVisitAdded",
-                    "payload": {
-                        "personType": "Deputy",
-                        "personId": "66",
-                        "personUid": "7000-0000-2118",
-                        "personName": "test62f136dbe2b13 Bold",
-                        "changes": [
-                            {
-                                "fieldName": "requestedDate",
-                                "newValue": "06/09/2022",
-                                "type": "string"
-                            },
-                            {
-                                "fieldName": "requestedBy",
-                                "newValue": "Finance User Testing",
-                                "type": "string"
-                            }
-                        ]
-                    }
+                    "personType": "Deputy",
+                    "personId": "66",
+                    "personUid": "7000-0000-2118",
+                    "personName": "test62f136dbe2b13 Bold",
+                    "changes": [
+                        {
+                            "fieldName": "requestedDate",
+                            "newValue": "06/09/2022",
+                            "type": "string"
+                        },
+                        {
+                            "fieldName": "requestedBy",
+                            "newValue": "Finance User Testing",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": 397,
+                "hash": "AY",
+                "timestamp": "2021-10-10 15:01:59",
+                "eventType": "Opg\\Core\\Model\\Event\\Common\\TaskCreated",
+                "user": {
+                    "id": 21,
+                    "phoneNumber": "0123456789",
+                    "displayName": "Lay Team 1 - (Supervision)",
+                    "email": "LayTeam1.team@opgtest.com"
+                },
+                "event": {
+                    "isCaseEvent": false,
+                    "isPersonEvent": true,
+                    "taskId": 249,
+                    "taskType": "AVFU",
+                    "dueDate": "2023-07-13 00:00:00",
+                    "description": "This is a note",
+                    "name": "",
+                    "assigneeId": "28",
+                    "assignee": "PA Team Workflow",
+                    "isCaseOwnerTask": false,
+                    "personType": "Deputy",
+                    "personId": "76",
+                    "personUid": "7000-0000-2530",
+                    "personName": "Bobby Deputiser"
                 }
             }
         ],

--- a/json-server/config/db.js
+++ b/json-server/config/db.js
@@ -1701,6 +1701,20 @@ module.exports = function () {
                 "name": "Email received",
                 "createdTime": "20/09/2021 08:50:12",
                 "direction": null
+            },
+            {
+                "personId": 1,
+                "userId": 68,
+                "userDisplayName": "Finance User Testing",
+                "userEmail": "finance.user.testing@opgtest.com",
+                "userPhoneNumber": "12345678",
+                "id": 64,
+                "type": "GE",
+                "noteType": "TASK_CREATED",
+                "description": "Some general enquiry on whether tasks appear correctly in the notes tab",
+                "name": "General enquiry",
+                "createdTime": "19/09/2021 08:50:12",
+                "direction": null
             }
         ],
         "errors": [

--- a/json-server/config/db.js
+++ b/json-server/config/db.js
@@ -1703,6 +1703,20 @@ module.exports = function () {
                 "direction": null
             },
             {
+                "personId": 2,
+                "userId": 68,
+                "userDisplayName": "Finance User Testing",
+                "userEmail": "finance.user.testing@opgtest.com",
+                "userPhoneNumber": "12345678",
+                "id": 66,
+                "type": "NEW DEPUTY",
+                "noteType": "NOTE_ADDED",
+                "description": "Note text entered",
+                "name": "New note title",
+                "createdTime": "20/09/2021 08:50:13",
+                "direction": null
+            },
+            {
                 "personId": 3,
                 "userId": 68,
                 "userDisplayName": "Finance User Testing",

--- a/json-server/config/db.js
+++ b/json-server/config/db.js
@@ -1703,7 +1703,7 @@ module.exports = function () {
                 "direction": null
             },
             {
-                "personId": 1,
+                "personId": 3,
                 "userId": 68,
                 "userDisplayName": "Finance User Testing",
                 "userEmail": "finance.user.testing@opgtest.com",

--- a/json-server/config/routes.json
+++ b/json-server/config/routes.json
@@ -3,7 +3,7 @@
     "/deputies/pa/:personId/clients*": "/clients",
     "/deputies/pro/:personId/clients*": "/clients",
     "/timeline/:personId": "/timeline",
-    "/:personId/notes": "/notes",
+    "/deputy/:personId/notes": "/notes?personId=:personId",
     "/users/current": "/users",
     "/deputies/:deputyId/ecm": "/ecm",
     "/deputies/:id/contact-details": "/deputies/:id",

--- a/web/template/assurance-visit/view-pdr.gotmpl
+++ b/web/template/assurance-visit/view-pdr.gotmpl
@@ -15,7 +15,7 @@
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Requested by</dt>
             <dd class="govuk-summary-list__value hook_requested_by">
-                {{ .RequestedBy.UserDisplayName }}
+                {{ .RequestedBy.Name }}
             </dd>
         </div>
         {{ $nullDateValue:="01/01/0001" }}
@@ -62,8 +62,8 @@
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Reviewed by</dt>
             <dd class="govuk-summary-list__value hook_reviewed_by">
-                {{ if .ReviewedBy.UserDisplayName }}
-                    {{ .ReviewedBy.UserDisplayName }}
+                {{ if .ReviewedBy.Name }}
+                    {{ .ReviewedBy.Name }}
                 {{ else }}
                     -
                 {{ end }}

--- a/web/template/assurance-visit/view-visit.gotmpl
+++ b/web/template/assurance-visit/view-visit.gotmpl
@@ -15,7 +15,7 @@
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Requested by</dt>
             <dd class="govuk-summary-list__value hook_requested_by">
-                {{ .RequestedBy.UserDisplayName }}
+                {{ .RequestedBy.Name }}
             </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -82,8 +82,8 @@
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Reviewed by</dt>
             <dd class="govuk-summary-list__value hook_reviewed_by">
-                {{ if .ReviewedBy.UserDisplayName }}
-                    {{ .ReviewedBy.UserDisplayName }}
+                {{ if .ReviewedBy.Name }}
+                    {{ .ReviewedBy.Name }}
                 {{ else }}
                     -
                 {{ end }}

--- a/web/template/notes.gotmpl
+++ b/web/template/notes.gotmpl
@@ -1,3 +1,4 @@
+{{- /*gotype: github.com/ministryofjustice/opg-sirius-supervision-deputy-hub/internal/server.deputyHubNotesVars*/ -}}
 {{ template "page" . }}
 {{ define "main" }}
 {{ if .SuccessMessage }}
@@ -28,7 +29,13 @@
         {{ range .DeputyNotes }}
             <div class="moj-timeline__item">
                 <div class="moj-timeline__header">
-                    <h2 class="moj-timeline__title">{{ .Name }}</h2>
+                    <h2 class="moj-timeline__title">
+                        {{ if eq .NoteType "TASK_CREATED" }}
+                            {{ printf "%v task created" .Name }}
+                        {{ else }}
+                            {{ .Name }}
+                        {{ end }}
+                    </h2>
                     <p class="moj-timeline__byline">
                         {{ printf "by %v (%v)" .UserDisplayName .UserPhoneNumber }}
                     </p>

--- a/web/template/timeline/assurance-visit-added.gotmpl
+++ b/web/template/timeline/assurance-visit-added.gotmpl
@@ -3,7 +3,7 @@
         <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">Assurance process created</h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
         <p class="moj-timeline__date">

--- a/web/template/timeline/assurance-visit-updated.gotmpl
+++ b/web/template/timeline/assurance-visit-updated.gotmpl
@@ -3,7 +3,7 @@
         <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">Assurance process updated</h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
         <p class="moj-timeline__date">

--- a/web/template/timeline/deputy-allocated-to-firm.gotmpl
+++ b/web/template/timeline/deputy-allocated-to-firm.gotmpl
@@ -3,7 +3,7 @@
         <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">Deputy firm updated</h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
         <p class="moj-timeline__date">

--- a/web/template/timeline/deputy-details-contact-changed.gotmpl
+++ b/web/template/timeline/deputy-details-contact-changed.gotmpl
@@ -3,7 +3,7 @@
         <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">Deputy contact details changed</h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
         <p class="moj-timeline__date">

--- a/web/template/timeline/deputy-information-updated.gotmpl
+++ b/web/template/timeline/deputy-information-updated.gotmpl
@@ -5,7 +5,7 @@
                 Deputy's important information updated
             </h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
         <p class="moj-timeline__date">

--- a/web/template/timeline/new-client-added-to-deputyship.gotmpl
+++ b/web/template/timeline/new-client-added-to-deputyship.gotmpl
@@ -3,7 +3,7 @@
         <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">New client added to deputyship</h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
 
@@ -17,7 +17,7 @@
                 <li>Sirius ID: {{ .Event.SiriusId }}</li>
                 <li>Order type: {{ .Event.OrderType }}</li>
                 {{ range .Event.Client }}
-                    <li>Client: {{ .ClientName }}</li>
+                    <li>Client: {{ .Name }}</li>
                 {{ end }}
             </ul>
         </div>

--- a/web/template/timeline/pa-deputy-allocated-to-ecm.gotmpl
+++ b/web/template/timeline/pa-deputy-allocated-to-ecm.gotmpl
@@ -5,7 +5,7 @@
                 {{ printf "Executive Case Manager changed to %v" .Event.ExecutiveCaseManager }}
             </h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
         <p class="moj-timeline__date">

--- a/web/template/timeline/pa-deputy-changed.gotmpl
+++ b/web/template/timeline/pa-deputy-changed.gotmpl
@@ -3,7 +3,7 @@
         <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">Deputy team details changed</h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
         <p class="moj-timeline__date">

--- a/web/template/timeline/pa-deputy-created.gotmpl
+++ b/web/template/timeline/pa-deputy-created.gotmpl
@@ -2,7 +2,7 @@
     <div class="moj-timeline__item" data-cy="pa-created-event">
         <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">
-                Executive Case Manager set to Public Authority deputy team by
+                Executive Case Manager set to Public Authority deputy team
             </h2>
             <p class="moj-timeline__byline">
                 {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}

--- a/web/template/timeline/pa-deputy-created.gotmpl
+++ b/web/template/timeline/pa-deputy-created.gotmpl
@@ -5,7 +5,7 @@
                 Executive Case Manager set to Public Authority deputy team
             </h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
         <p class="moj-timeline__date">

--- a/web/template/timeline/task-created.gotmpl
+++ b/web/template/timeline/task-created.gotmpl
@@ -2,7 +2,7 @@
     <div class="moj-timeline__item" data-cy="task-created-event">
         <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">
-                {{ .Event.TaskType }} task created by
+                {{ .Event.TaskType }} task created
             </h2>
             <p class="moj-timeline__byline">
                 {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}

--- a/web/template/timeline/task-created.gotmpl
+++ b/web/template/timeline/task-created.gotmpl
@@ -5,7 +5,7 @@
                 {{ .Event.TaskType }} task created
             </h2>
             <p class="moj-timeline__byline">
-                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+                {{ printf "by %v (%v)" .User.Name .User.PhoneNumber }}
             </p>
         </div>
         <p class="moj-timeline__date">

--- a/web/template/timeline/task-created.gotmpl
+++ b/web/template/timeline/task-created.gotmpl
@@ -1,0 +1,28 @@
+{{ define "task-created" }}
+    <div class="moj-timeline__item" data-cy="task-created-event">
+        <div class="moj-timeline__header">
+            <h2 class="moj-timeline__title">
+                {{ .Event.TaskType }} task created by
+            </h2>
+            <p class="moj-timeline__byline">
+                {{ printf "by %v (%v)" .User.UserDisplayName .User.UserPhoneNumber }}
+            </p>
+        </div>
+        <p class="moj-timeline__date">
+            <time>{{ .Timestamp }}</time>
+        </p>
+        <div class="moj-timeline__description">
+            <ul class="govuk-list govuk-list--bullet">
+                <li>
+                    Assigned to {{ .Event.Assignee }}
+                </li>
+                <li>
+                    Due date {{ .Event.DueDate }}
+                </li>
+                <li>
+                    {{ .Event.Notes }}
+                </li>
+            </ul>
+        </div>
+    </div>
+{{ end }}

--- a/web/template/timeline/timeline-template-renderer.gotmpl
+++ b/web/template/timeline/timeline-template-renderer.gotmpl
@@ -26,4 +26,7 @@
     {{ if eq .EventType "AssuranceVisitUpdated" }}
         {{ template "assurance-visit-updated" . }}
     {{ end }}
+    {{ if eq .EventType "TaskCreated" }}
+        {{ template "task-created" . }}
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
Frustratingly, task events don't come with their task type display name, only their code, which means I've had to conditionally fetch the task types if there is a task event. I've done this in the `sirius` package as that way it cuts down on the number of times we have to iterate over the event collection. However, this isn't something we have done previously as API calls are usually handled individually and data is merged on the `server` side. I'm pretty vague on what the rationale was behind the separation in the first place though, so I don't know if there is a "right" answer.

Alternatively, we could amend Sirius to provide this information, but again it is awkward because the task types are not actually in the database, which would mean we would have to map the list of task types to the data after querying for it anyway. Opinions welcome!