### PR TITLE
SW-7006 Fix empty clients status filter

### DIFF
--- a/internal/server/deputy_hub.go
+++ b/internal/server/deputy_hub.go
@@ -26,6 +26,7 @@ func renderTemplateForDeputyHub(client DeputyHubInformation, tmpl Template) Hand
 		ctx := getContext(r)
 
 		var selectedOrderStatuses []string
+		selectedOrderStatuses = append(selectedOrderStatuses, "ACTIVE")
 
 		params := sirius.ClientListParams{
 			DeputyId:      app.DeputyId(),


### PR DESCRIPTION
Fix the clients tab only returning active clients when the 'order status' filter is empty, by adding the order status filter 'active' when fetching client count