### PR TITLE
SW-7246: Sirius API calls should be routed to /supervision-api, not /api (Deputy hub)

### DIFF
--- a/internal/sirius/add_assurance_test.go
+++ b/internal/sirius/add_assurance_test.go
@@ -41,7 +41,7 @@ func TestAddAssuranceReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/assurances",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/assurances",
 		Method: http.MethodPost,
 	}, err)
 }

--- a/internal/sirius/add_document_test.go
+++ b/internal/sirius/add_document_test.go
@@ -68,7 +68,7 @@ func TestAddDocumentReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/68/documents",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/68/documents",
 		Method: http.MethodPost,
 	}, err)
 }

--- a/internal/sirius/add_firm_test.go
+++ b/internal/sirius/add_firm_test.go
@@ -66,7 +66,7 @@ func TestAddFirmReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/firms",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/firms",
 		Method: http.MethodPost,
 	}, err)
 

--- a/internal/sirius/add_gcm_issue_test.go
+++ b/internal/sirius/add_gcm_issue_test.go
@@ -61,7 +61,7 @@ func TestAddGcmIssueReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/gcm-issues",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/gcm-issues",
 		Method: http.MethodPost,
 	}, err)
 }

--- a/internal/sirius/add_note_test.go
+++ b/internal/sirius/add_note_test.go
@@ -64,7 +64,7 @@ func TestAddDeputyNoteReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/notes",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/notes",
 		Method: http.MethodPost,
 	}, err)
 }

--- a/internal/sirius/add_task_test.go
+++ b/internal/sirius/add_task_test.go
@@ -53,7 +53,7 @@ func TestAddTaskReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/tasks",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/tasks",
 		Method: http.MethodPost,
 	}, err)
 }

--- a/internal/sirius/assign_deputy_to_firm_test.go
+++ b/internal/sirius/assign_deputy_to_firm_test.go
@@ -44,7 +44,7 @@ func TestAssignDeputyToFirmReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/firm",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/firm",
 		Method: http.MethodPut,
 	}, err)
 }

--- a/internal/sirius/change_ecm_test.go
+++ b/internal/sirius/change_ecm_test.go
@@ -41,7 +41,7 @@ func TestChangeECMReturnsErrorIfNoEcm(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/ecm",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/ecm",
 		Method: http.MethodPut,
 	}, err)
 }
@@ -59,7 +59,7 @@ func TestChangeECMReturnsErrorIfNoId(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/0/ecm",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/0/ecm",
 		Method: http.MethodPut,
 	}, err)
 }
@@ -78,7 +78,7 @@ func TestChangeECMReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/ecm",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/ecm",
 		Method: http.MethodPut,
 	}, err)
 }

--- a/internal/sirius/complete_task_test.go
+++ b/internal/sirius/complete_task_test.go
@@ -42,7 +42,7 @@ func TestCompleteTaskReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/tasks/51/mark-as-completed",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/tasks/51/mark-as-completed",
 		Method: http.MethodPut,
 	}, err)
 }
@@ -59,7 +59,7 @@ func TestCompleteTaskReturnsErrorIfNoTaskId(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/tasks/0/mark-as-completed",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/tasks/0/mark-as-completed",
 		Method: http.MethodPut,
 	}, err)
 }
@@ -77,7 +77,7 @@ func TestCompleteTaskReturnsUnauthorisedClientError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/tasks/155/mark-as-completed",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/tasks/155/mark-as-completed",
 		Method: http.MethodPut,
 	}, err)
 }

--- a/internal/sirius/constants.go
+++ b/internal/sirius/constants.go
@@ -1,0 +1,5 @@
+package sirius
+
+const (
+	SupervisionAPIPath = "/supervision-api"
+)

--- a/internal/sirius/delete_contact_test.go
+++ b/internal/sirius/delete_contact_test.go
@@ -39,7 +39,7 @@ func TestDeleteContactReturnsNewStatusError(t *testing.T) {
 	err := client.DeleteContact(getContext(nil), 76, 1)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/contacts/1",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/contacts/1",
 		Method: http.MethodDelete,
 	}, err)
 }

--- a/internal/sirius/edit_deputy_details_test.go
+++ b/internal/sirius/edit_deputy_details_test.go
@@ -83,7 +83,7 @@ func TestEditDeputyDetailsReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/32",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/32",
 		Method: http.MethodPut,
 	}, err)
 }

--- a/internal/sirius/get_accommodation_types_test.go
+++ b/internal/sirius/get_accommodation_types_test.go
@@ -67,7 +67,7 @@ func TestGetAccommodationTypesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []model.RefData(nil), accommodationTypes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/reference-data?filter=clientAccommodation",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/reference-data?filter=clientAccommodation",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_assurance_test.go
+++ b/internal/sirius/get_assurance_test.go
@@ -102,7 +102,7 @@ func TestGetAssuranceReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, assurance)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/assurances/1",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/assurances/1",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_assurances_test.go
+++ b/internal/sirius/get_assurances_test.go
@@ -155,7 +155,7 @@ func TestGetAssurancesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, assurances)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/assurances",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/assurances",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_contact_test.go
+++ b/internal/sirius/get_contact_test.go
@@ -62,7 +62,7 @@ func TestGetContactReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, contact)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/contacts/1",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/contacts/1",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_annual_billing_invoice_types_test.go
+++ b/internal/sirius/get_deputy_annual_billing_invoice_types_test.go
@@ -81,7 +81,7 @@ func TestGetAnnualBillingInvoiceTypesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []model.RefData(nil), invoiceTypes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/reference-data/annualBillingInvoice",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/reference-data/annualBillingInvoice",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_boolean_types_test.go
+++ b/internal/sirius/get_deputy_boolean_types_test.go
@@ -73,7 +73,7 @@ func TestGetDeputyBooleanTypesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []model.RefData(nil), deputyBooleanTypes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/reference-data/deputyBooleanType",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/reference-data/deputyBooleanType",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_client_test.go
+++ b/internal/sirius/get_deputy_client_test.go
@@ -88,7 +88,7 @@ func TestGetDeputyClientReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, contact)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/client/123456",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/client/123456",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_clients_test.go
+++ b/internal/sirius/get_deputy_clients_test.go
@@ -170,7 +170,7 @@ func TestGetDeputyClientsReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, clientList)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/pa/1/clients?&limit=25&page=1&sort=&filter=order-status:ACTIVE,accommodation:COUNCIL%20RENTED,accommodation:NO%20ACCOMMODATION%20TYPE,supervision-level:GENERAL,supervision-level:MINIMAL",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/pa/1/clients?&limit=25&page=1&sort=&filter=order-status:ACTIVE,accommodation:COUNCIL%20RENTED,accommodation:NO%20ACCOMMODATION%20TYPE,supervision-level:GENERAL,supervision-level:MINIMAL",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_contacts_test.go
+++ b/internal/sirius/get_deputy_contacts_test.go
@@ -67,7 +67,7 @@ func TestGetDeputyContactReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, contacts)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/1/contacts",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/1/contacts",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_details_test.go
+++ b/internal/sirius/get_deputy_details_test.go
@@ -286,7 +286,7 @@ func TestGetDeputyDetailsReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, deputyDetails)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/1",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/1",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_document_test.go
+++ b/internal/sirius/get_deputy_document_test.go
@@ -108,7 +108,7 @@ func TestGetDocumentReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, document)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/documents/1",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/documents/1",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_documents_test.go
+++ b/internal/sirius/get_deputy_documents_test.go
@@ -143,7 +143,7 @@ func TestGetDeputyDocumentsReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, deputyDocuments)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/persons/76/documents?&sort=receiveddatetime:desc",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/persons/76/documents?&sort=receiveddatetime:desc",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_events_test.go
+++ b/internal/sirius/get_deputy_events_test.go
@@ -270,7 +270,7 @@ func TestGetDeputyEventsReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, deputyEvents)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/timeline/76/deputy?limit=25&page=1",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/timeline/76/deputy?limit=25&page=1",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_notes_test.go
+++ b/internal/sirius/get_deputy_notes_test.go
@@ -106,7 +106,7 @@ func TestGetDeputyNotesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, deputyNotes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/notes",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/notes",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_report_system_types_test.go
+++ b/internal/sirius/get_deputy_report_system_types_test.go
@@ -105,7 +105,7 @@ func TestGetDeputyReportSystemTypesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []model.RefData(nil), deputyReportSystemTypes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/reference-data/deputyReportSystem",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/reference-data/deputyReportSystem",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_deputy_team_users_test.go
+++ b/internal/sirius/get_deputy_team_users_test.go
@@ -159,7 +159,7 @@ func TestGetDeputyTeamUsersReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, paDeputyTeam)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/teams/23",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/teams/23",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_firms_test.go
+++ b/internal/sirius/get_firms_test.go
@@ -78,7 +78,7 @@ func TestGetFirmsReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []FirmForList(nil), firms)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/firms",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/firms",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_gcm_issues_test.go
+++ b/internal/sirius/get_gcm_issues_test.go
@@ -118,7 +118,7 @@ func TestGetGcmIssuesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, contact)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/gcm-issues?&filter=&sort=",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/gcm-issues?&filter=&sort=",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_pdr_outcome_types_test.go
+++ b/internal/sirius/get_pdr_outcome_types_test.go
@@ -65,7 +65,7 @@ func TestGetPdrOutcomeTypesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []model.RefData(nil), pdrOutcomeTypes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/reference-data/pdrOutcome",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/reference-data/pdrOutcome",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_rag_rating_types_test.go
+++ b/internal/sirius/get_rag_rating_types_test.go
@@ -73,7 +73,7 @@ func TestGetRagRatingTypesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []model.RAGRating(nil), ragRatingTypes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/reference-data/ragRating",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/reference-data/ragRating",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_refdata_test.go
+++ b/internal/sirius/get_refdata_test.go
@@ -127,7 +127,7 @@ func TestGetRefDataReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []model.RefData(nil), accommodationTypes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/reference-data?filter=clientAccommodation",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/reference-data?filter=clientAccommodation",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_supervision_levels_test.go
+++ b/internal/sirius/get_supervision_levels_test.go
@@ -62,7 +62,7 @@ func TestGetSupervisionLevelsReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []model.RefData(nil), supervisionLevel)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/reference-data?filter=supervisionLevel",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/reference-data?filter=supervisionLevel",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_task_test.go
+++ b/internal/sirius/get_task_test.go
@@ -75,7 +75,7 @@ func TestGetTaskReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, model.Task{}, task)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/tasks/119",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/tasks/119",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_task_types_test.go
+++ b/internal/sirius/get_task_types_test.go
@@ -103,7 +103,7 @@ func TestGetTaskTypes_statusError(t *testing.T) {
 	assert.Equal(t, []model.TaskType(nil), taskTypes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/tasktypes/deputy",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/tasktypes/deputy",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_tasks_test.go
+++ b/internal/sirius/get_tasks_test.go
@@ -120,7 +120,7 @@ func TestGetTasksReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, TaskList{Tasks: []model.Task(nil), TotalTasks: 0, Pages: PageInformation{Current: 0, Total: 0}}, tasks)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/tasks?filter=status:Not+started&sort=dueDate:asc",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/tasks?filter=status:Not+started&sort=dueDate:asc",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_user_details_test.go
+++ b/internal/sirius/get_user_details_test.go
@@ -55,7 +55,7 @@ func TestUserDetailsReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, userDetails)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/users/current",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/users/current",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_visit_outcome_types_test.go
+++ b/internal/sirius/get_visit_outcome_types_test.go
@@ -73,7 +73,7 @@ func TestGetVisitOutcomeTypesReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, []model.RefData(nil), visitOutcomeTypes)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/reference-data/visitOutcome",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/reference-data/visitOutcome",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/get_visitors_test.go
+++ b/internal/sirius/get_visitors_test.go
@@ -75,7 +75,7 @@ func TestGetVisitorsReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, visitors)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/visitors",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/visitors",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/internal/sirius/replace_deputy_document_test.go
+++ b/internal/sirius/replace_deputy_document_test.go
@@ -79,7 +79,7 @@ func TestReplaceDocumentReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/68/documents/5",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/68/documents/5",
 		Method: http.MethodPut,
 	}, err)
 }

--- a/internal/sirius/update_assurance_test.go
+++ b/internal/sirius/update_assurance_test.go
@@ -47,7 +47,7 @@ func TestUpdateAssuranceReturnsNewStatusError(t *testing.T) {
 	err := client.UpdateAssurance(getContext(nil), UpdateAssuranceDetails{}, 53, 76)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/53/assurances/76",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/53/assurances/76",
 		Method: http.MethodPut,
 	}, err)
 }

--- a/internal/sirius/update_contact_test.go
+++ b/internal/sirius/update_contact_test.go
@@ -47,7 +47,7 @@ func TestUpdateContactReturnsNewStatusError(t *testing.T) {
 	err := client.UpdateContact(getContext(nil), 76, 1, ContactForm{})
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/deputies/76/contacts/1",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/deputies/76/contacts/1",
 		Method: http.MethodPut,
 	}, err)
 }

--- a/internal/sirius/update_task_test.go
+++ b/internal/sirius/update_task_test.go
@@ -45,7 +45,7 @@ func TestUpdateTaskReturnsNewStatusError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/tasks/51",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/tasks/51",
 		Method: http.MethodPut,
 	}, err)
 }
@@ -62,7 +62,7 @@ func TestUpdateTaskReturnsErrorIfNoTaskId(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/tasks/0",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/tasks/0",
 		Method: http.MethodPut,
 	}, err)
 }
@@ -80,7 +80,7 @@ func TestUpdateTaskReturnsUnauthorisedClientError(t *testing.T) {
 
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/tasks/155",
+		URL:    svr.URL + SupervisionAPIPath + "/v1/tasks/155",
 		Method: http.MethodPut,
 	}, err)
 }


### PR DESCRIPTION
https://opgtransform.atlassian.net/browse/SW-7246