### PR TITLE
SFS-601 Allow timestamp to be IsoDateTime or IsoDateTimeZone format #patch

### DIFF
--- a/internal/sirius/format_date_and_time.go
+++ b/internal/sirius/format_date_and_time.go
@@ -1,6 +1,9 @@
 package sirius
 
-import "time"
+import (
+	"regexp"
+	"time"
+)
 
 const IsoDateTimeZone string = "2006-01-02T15:04:05+00:00"
 const IsoDateTime string = "2006-01-02 15:04:05"
@@ -15,4 +18,21 @@ func FormatDateTime(currentFormat string, dateString string, displayFormat strin
 	stringToDateTime, _ := time.Parse(currentFormat, dateString)
 	dateTime := stringToDateTime.Local().Format(displayFormat)
 	return dateTime
+}
+
+// PermissiveFormatIsoDateTime allows transition from `IsoDateTime` to `IsoDateTimeZone` without display errors for users.
+// Once the transition is completed, this should be deleted and `FormatDateTime(IsoDateTimeZone, ...` used.
+func PermissiveFormatIsoDateTime(dateString string, displayFormat string) string {
+	if dateString == "" {
+		return dateString
+	}
+
+	re := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}$`)
+	if re.MatchString(dateString) {
+		stringToDateTime, _ := time.Parse(IsoDateTimeZone, dateString)
+		return stringToDateTime.Local().Format(displayFormat)
+	}
+
+	stringToDateTime, _ := time.Parse(IsoDateTime, dateString)
+	return stringToDateTime.Local().Format(displayFormat)
 }

--- a/internal/sirius/get_deputy_events.go
+++ b/internal/sirius/get_deputy_events.go
@@ -72,7 +72,7 @@ func editDeputyEvents(events DeputyEvents, taskTypes TaskTypeMap) DeputyEvents {
 	var list DeputyEvents
 	for _, e := range events {
 		event := model.DeputyEvent{
-			Timestamp:  FormatDateTime(IsoDateTime, e.Timestamp, SiriusDateTime),
+			Timestamp:  PermissiveFormatIsoDateTime(e.Timestamp, SiriusDateTime),
 			EventType:  reformatEventType(e.EventType),
 			ID:         e.ID,
 			User:       e.User,

--- a/internal/sirius/get_deputy_events_test.go
+++ b/internal/sirius/get_deputy_events_test.go
@@ -41,7 +41,7 @@ func TestDeputyEventsReturned(t *testing.T) {
 		  {
 			"id": 300,
 			"hash": "AW",
-			"timestamp": "2023-07-31 08:45:22",
+			"timestamp": "2023-07-31T08:45:22+00:00",
 			"eventType": "Opg\\Core\\Model\\Event\\Order\\DeputyLinkedToOrder",
 			"user": {
 			  "id": 41,


### PR DESCRIPTION
After related API changes are released, timestamp will always be IsoDateTimeZone and dual support can be removed